### PR TITLE
Allow task to be gated

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Schedule future prompts with natural language:
   - **Recurring** (cron/interval) — repeats automatically
   - **One-shot** (once) — runs once then auto-disables
 - **Actions**: add, remove, list, enable, disable, update, cleanup
+- **Optional gates**: Run a command before firing; prompts only fire when the gate exits with `0`
 - **Auto-cleanup**: Removes disabled jobs on session exit
 
 ### Use Cases
@@ -85,6 +86,11 @@ You: Remind me to check the deployment logs in 10 minutes
 
 Agent: [calls schedule_prompt with schedule="+10m", prompt="check the deployment logs"]
 ✓ Scheduled job "abc123" to run in 10 minutes
+
+You: Remind me to check the deployment logs in 10 minutes if gate.sh passes
+
+Agent: [calls schedule_prompt with schedule="+10m", prompt="deploy", gate="./gate.sh"]
+✓ Scheduled job "abc123" to run in 10 minutes with gate "/path/to/project/gate.sh"
 ```
 
 The widget displays below your editor (only when jobs exist):

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,7 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Key } from "@mariozechner/pi-tui";
-import { Container, Text } from "@mariozechner/pi-tui";
+import { Text } from "@mariozechner/pi-tui";
 import { CronStorage } from "./storage.js";
 import { CronScheduler } from "./scheduler.js";
 import { createCronTool } from "./tool.js";
@@ -26,13 +25,17 @@ export default async function (pi: ExtensionAPI) {
 
   // Register custom message renderer for scheduled prompts
   pi.registerMessageRenderer("scheduled_prompt", (message, _options, theme) => {
-    const details = message.details as { jobId: string; jobName: string; prompt: string } | undefined;
+    const details = message.details as
+      | { jobId: string; jobName: string; prompt: string; gate?: string; gateBlocked?: boolean }
+      | undefined;
     const jobName = details?.jobName || "Unknown";
     const prompt = details?.prompt || "";
-    
+    const gateBlocked = details?.gateBlocked === true;
+
     return new Text(
-      theme.fg("accent", `🕐 Scheduled: ${jobName}`) + 
-      (prompt ? theme.fg("dim", ` → "${prompt}"`) : ""),
+      theme.fg("accent", `🕐 Scheduled: ${jobName}`) +
+        (prompt ? theme.fg("dim", ` → "${prompt}"`) : "") +
+        (gateBlocked ? theme.fg("dim", " did not fire due to non-zero gate.") : ""),
       0,
       0
     );
@@ -154,6 +157,9 @@ export default async function (pi: ExtensionAPI) {
             lines.push(`${status} ${job.name} (${job.id})`);
             lines.push(`  Schedule: ${job.schedule} | Type: ${job.type}`);
             lines.push(`  Prompt: ${job.prompt}`);
+            if (job.gate) {
+              lines.push(`  Gate: ${job.gate}`);
+            }
             if (nextRun) {
               lines.push(`  Next run: ${nextRun.toISOString()}`);
             }
@@ -198,10 +204,18 @@ export default async function (pi: ExtensionAPI) {
           const prompt = await ctx.ui.input("Prompt", "Enter the prompt to execute");
           if (!prompt) return;
 
+          const gateInput = await ctx.ui.input(
+            "Gate (optional)",
+            "Enter a gate command to run before firing the prompt, or leave blank"
+          );
+
           // Validate and create job
           try {
             let intervalMs: number | undefined;
             let validatedSchedule = schedule;
+            const gate = gateInput
+              ? CronScheduler.resolveGateCommand(gateInput, ctx.cwd)
+              : undefined;
 
             if (jobType === "interval") {
               const parsed = CronScheduler.parseInterval(schedule);
@@ -230,6 +244,7 @@ export default async function (pi: ExtensionAPI) {
               name,
               schedule: validatedSchedule,
               prompt,
+              gate,
               enabled: true,
               type: jobType as any,
               intervalMs,

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "fs";
+import { spawn } from "child_process";
+import path from "path";
 import { Cron } from "croner";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import type { CronJob, CronChangeEvent } from "./types.js";
@@ -107,7 +110,7 @@ export class CronScheduler {
         if (delay > 0) {
           const timeout = setTimeout(() => {
             this.executeJob(job);
-            // Auto-disable one-shot jobs after execution
+            // Auto-disable one-shot jobs after execution attempt
             this.storage.updateJob(job.id, { enabled: false });
             this.emitChange({ type: "update", job: { ...job, enabled: false } });
           }, delay);
@@ -116,14 +119,14 @@ export class CronScheduler {
         } else {
           // Job is in the past - disable it and log warning
           console.warn(`Job ${job.id} (${job.name}) scheduled for past time: ${job.schedule}`);
-          this.storage.updateJob(job.id, { 
+          this.storage.updateJob(job.id, {
             enabled: false,
-            lastStatus: "error" 
+            lastStatus: "error",
           });
-          this.emitChange({ 
-            type: "error", 
-            jobId: job.id, 
-            error: `Scheduled time ${job.schedule} is in the past` 
+          this.emitChange({
+            type: "error",
+            jobId: job.id,
+            error: `Scheduled time ${job.schedule} is in the past`,
           });
         }
       } else {
@@ -173,15 +176,45 @@ export class CronScheduler {
       });
       this.emitChange({ type: "fire", job });
 
-      // Send a visible marker message for the scheduled prompt
-      this.pi.sendMessage(
-        {
-          customType: "scheduled_prompt",
-          content: [{ type: "text", text: job.prompt }],
-          display: true,
-          details: { jobId: job.id, jobName: job.name, prompt: job.prompt },
+      if (job.gate) {
+        const gatePassed = await this.runGate(job.gate);
+        if (!gatePassed) {
+          const nextRun = this.getNextRun(job.id);
+          this.storage.updateJob(job.id, {
+            lastRun: new Date().toISOString(),
+            lastStatus: "error",
+            nextRun: nextRun?.toISOString(),
+          });
+
+          this.pi.sendMessage({
+            customType: "scheduled_prompt",
+            content: [{ type: "text", text: job.prompt }],
+            display: true,
+            details: {
+              jobId: job.id,
+              jobName: job.name,
+              prompt: job.prompt,
+              gate: job.gate,
+              gateBlocked: true,
+            },
+          });
+
+          this.emitChange({
+            type: "error",
+            jobId: job.id,
+            error: `Gate exited non-zero for job ${job.name}`,
+          });
+          return;
         }
-      );
+      }
+
+      // Send a visible marker message for the scheduled prompt
+      this.pi.sendMessage({
+        customType: "scheduled_prompt",
+        content: [{ type: "text", text: job.prompt }],
+        display: true,
+        details: { jobId: job.id, jobName: job.name, prompt: job.prompt, gate: job.gate },
+      });
 
       // Then send the actual prompt to the agent
       this.pi.sendUserMessage(job.prompt, { deliverAs: "followUp" });
@@ -208,6 +241,30 @@ export class CronScheduler {
         error: error instanceof Error ? error.message : String(error),
       });
     }
+  }
+
+  /**
+   * Run a gate command and return true only when it exits with code 0
+   */
+  private async runGate(gate: string): Promise<boolean> {
+    const cwd = this.storage.getCwd();
+    const resolvedGate = CronScheduler.resolveGateCommand(gate, cwd);
+
+    return new Promise<boolean>((resolve) => {
+      const child = spawn(resolvedGate, [], {
+        cwd,
+        stdio: "ignore",
+      });
+
+      child.on("error", (error) => {
+        console.error(`Failed to execute gate \"${resolvedGate}\":`, error);
+        resolve(false);
+      });
+
+      child.on("close", (code) => {
+        resolve(code === 0);
+      });
+    });
   }
 
   /**
@@ -252,7 +309,7 @@ export class CronScheduler {
 
     const value = parseInt(match[1], 10);
     const unit = match[2];
-    
+
     const msMap: Record<string, number> = {
       s: 1000,
       m: 60 * 1000,
@@ -283,5 +340,33 @@ export class CronScheduler {
     };
 
     return value * multipliers[unit];
+  }
+
+  /**
+   * Resolve a gate command against cwd when the executable path is relative.
+   * Supports simple quoted first tokens and leaves non-path commands unchanged.
+   */
+  static resolveGateCommand(gate: string, cwd: string): string {
+    const trimmed = gate.trim();
+    const command =
+      trimmed.length >= 2 &&
+      ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+        (trimmed.startsWith("'") && trimmed.endsWith("'")))
+        ? trimmed.slice(1, -1)
+        : trimmed;
+
+    if (!command || path.isAbsolute(command) || !CronScheduler.shouldResolveCommand(command, cwd)) {
+      return command;
+    }
+
+    return path.resolve(cwd, command);
+  }
+
+  private static shouldResolveCommand(command: string, cwd: string): boolean {
+    return (
+      command.startsWith(".") ||
+      command.includes("/") ||
+      existsSync(path.resolve(cwd, command))
+    );
   }
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -6,10 +6,12 @@ import type { CronJob, CronStore } from "./types.js";
  * Handles persistence of scheduled prompts to .pi/schedule-prompts.json
  */
 export class CronStorage {
+  private readonly cwd: string;
   private readonly storePath: string;
   private readonly piDir: string;
 
   constructor(cwd: string) {
+    this.cwd = cwd;
     this.piDir = path.join(cwd, ".pi");
     this.storePath = path.join(this.piDir, "schedule-prompts.json");
   }
@@ -113,6 +115,13 @@ export class CronStorage {
   getAllJobs(): CronJob[] {
     const store = this.load();
     return store.jobs;
+  }
+
+  /**
+   * Get project working directory
+   */
+  getCwd(): string {
+    return this.cwd;
   }
 
   /**

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -1,10 +1,47 @@
-import type { ToolDefinition, Theme } from "@mariozechner/pi-coding-agent";
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { nanoid } from "nanoid";
-import type { CronToolParamsType, CronToolDetails, CronJob, CronJobType } from "./types.js";
+import type { CronToolDetails, CronJob, CronJobType } from "./types.js";
 import { CronToolParams } from "./types.js";
 import type { CronStorage } from "./storage.js";
 import { CronScheduler } from "./scheduler.js";
+
+function humanizeDuration(value: string): string | null {
+  const match = value.match(/^\+?(\d+)(s|m|h|d)$/);
+  if (!match) return null;
+
+  const amount = Number.parseInt(match[1], 10);
+  const unitMap: Record<string, string> = {
+    s: amount === 1 ? "second" : "seconds",
+    m: amount === 1 ? "minute" : "minutes",
+    h: amount === 1 ? "hour" : "hours",
+    d: amount === 1 ? "day" : "days",
+  };
+
+  return `${amount} ${unitMap[match[2]]}`;
+}
+
+function formatScheduledJobMessage(job: CronJob, originalSchedule: string): string {
+  const gateSuffix = job.gate ? ` with gate "${job.gate}"` : "";
+
+  if (job.type === "once") {
+    const delay = humanizeDuration(originalSchedule);
+    if (delay) {
+      return `✓ Scheduled job "${job.name}" to run in ${delay}${gateSuffix}`;
+    }
+    return `✓ Scheduled job "${job.name}" to run at ${job.schedule}${gateSuffix}`;
+  }
+
+  if (job.type === "interval") {
+    const every = humanizeDuration(originalSchedule);
+    if (every) {
+      return `✓ Scheduled job "${job.name}" to run every ${every}${gateSuffix}`;
+    }
+    return `✓ Scheduled job "${job.name}" to run on interval "${job.schedule}"${gateSuffix}`;
+  }
+
+  return `✓ Scheduled job "${job.name}" with schedule "${job.schedule}"${gateSuffix}`;
+}
 
 /**
  * Create the schedule_prompt tool definition
@@ -17,13 +54,13 @@ export function createCronTool(
     name: "schedule_prompt",
     label: "Schedule Prompt",
     description:
-      "IMPORTANT: For action='add', you MUST provide both 'schedule' parameter AND 'prompt' parameter. Schedule prompts at times/intervals. Schedule formats: 6-field cron (with seconds: '0 * * * * *' = every minute), ISO timestamp, relative time (+10s, +5m, +1h), or interval (5m, 1h). Type defaults to 'cron', use 'once' for relative/ISO times. Actions: add (needs schedule+prompt), list, remove/enable/disable/update (need jobId), cleanup.",
+      "IMPORTANT: For action='add', you MUST provide both 'schedule' parameter AND 'prompt' parameter. Schedule prompts at times/intervals. Schedule formats: 6-field cron (with seconds: '0 * * * * *' = every minute), ISO timestamp, relative time (+10s, +5m, +1h), or interval (5m, 1h). Optional 'gate' command only allows the prompt to fire when it exits with 0; relative executable paths are resolved against the current working directory. Type defaults to 'cron', use 'once' for relative/ISO times. Actions: add (needs schedule+prompt), list, remove/enable/disable/update (need jobId), cleanup.",
     parameters: CronToolParams,
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const storage = getStorage();
       const scheduler = getScheduler();
-      
+
       // Prevent recursive scheduling from within scheduled prompts
       if (params.action === "add") {
         const entries = ctx.sessionManager.getEntries();
@@ -31,14 +68,14 @@ export function createCronTool(
         const hasScheduledPrompt = recentEntries.some(
           (entry) => entry.type === "custom" && entry.customType === "scheduled_prompt"
         );
-        
+
         if (hasScheduledPrompt) {
           throw new Error(
             "Cannot create scheduled prompts from within a scheduled prompt execution. This prevents infinite loops."
           );
         }
       }
-      
+
       const action = params.action;
       const details: CronToolDetails = {
         action,
@@ -70,6 +107,9 @@ export function createCronTool(
             const type = (params.type || "cron") as CronJobType;
             let intervalMs: number | undefined;
             let schedule = params.schedule;
+            const gate = params.gate
+              ? CronScheduler.resolveGateCommand(params.gate, ctx.cwd)
+              : undefined;
 
             // Parse and validate based on type
             if (type === "interval") {
@@ -94,7 +134,7 @@ export function createCronTool(
                   );
                 }
                 schedule = date.toISOString();
-                
+
                 // Warn if scheduled in the past or very near future
                 const now = Date.now();
                 const delay = date.getTime() - now;
@@ -123,6 +163,7 @@ export function createCronTool(
               name: jobName,
               schedule,
               prompt: params.prompt,
+              gate,
               enabled: true,
               type,
               intervalMs,
@@ -141,7 +182,7 @@ export function createCronTool(
               content: [
                 {
                   type: "text",
-                  text: `✓ Created cron job "${job.name}" (${job.id})\nType: ${job.type}\nSchedule: ${job.schedule}\nPrompt: ${job.prompt}`,
+                  text: formatScheduledJobMessage(job, params.schedule),
                 },
               ],
               details,
@@ -212,7 +253,7 @@ export function createCronTool(
             // Remove all disabled jobs
             const allJobs = storage.getAllJobs();
             const disabledJobs = allJobs.filter((j) => !j.enabled);
-            
+
             if (disabledJobs.length === 0) {
               details.jobs = [];
               return {
@@ -257,6 +298,11 @@ export function createCronTool(
             const updates: Partial<CronJob> = {};
             if (params.name) updates.name = params.name;
             if (params.prompt) updates.prompt = params.prompt;
+            if (params.gate !== undefined) {
+              updates.gate = params.gate
+                ? CronScheduler.resolveGateCommand(params.gate, ctx.cwd)
+                : undefined;
+            }
             if (params.description !== undefined) updates.description = params.description;
 
             if (params.schedule) {
@@ -271,11 +317,16 @@ export function createCronTool(
                 updates.schedule = params.schedule;
                 updates.intervalMs = intervalMs;
               } else if (type === "once") {
-                const date = new Date(params.schedule);
-                if (isNaN(date.getTime())) {
-                  throw new Error(`Invalid timestamp: ${params.schedule}`);
+                const relativeTime = CronScheduler.parseRelativeTime(params.schedule);
+                if (relativeTime) {
+                  updates.schedule = relativeTime;
+                } else {
+                  const date = new Date(params.schedule);
+                  if (isNaN(date.getTime())) {
+                    throw new Error(`Invalid timestamp: ${params.schedule}`);
+                  }
+                  updates.schedule = date.toISOString();
                 }
-                updates.schedule = date.toISOString();
               } else {
                 const validation = CronScheduler.validateCronExpression(params.schedule);
                 if (!validation.valid) {
@@ -325,6 +376,9 @@ export function createCronTool(
               lines.push(`${status} ${job.name} (${job.id})`);
               lines.push(`  Type: ${job.type} | Schedule: ${job.schedule}`);
               lines.push(`  Prompt: ${job.prompt}`);
+              if (job.gate) {
+                lines.push(`  Gate: ${job.gate}`);
+              }
               lines.push(`  ${lastStr} ${nextStr ? `| ${nextStr}` : ""}`);
               lines.push(`  Runs: ${job.runCount} | Status: ${job.lastStatus || "pending"}`);
               if (job.description) {
@@ -415,6 +469,9 @@ export function createCronTool(
             `  ${theme.fg("dim", "Type:")} ${job.type} ${theme.fg("dim", "| Schedule:")} ${job.schedule}`
           );
           lines.push(`  ${theme.fg("dim", "Prompt:")} ${job.prompt}`);
+          if (job.gate) {
+            lines.push(`  ${theme.fg("dim", "Gate:")} ${job.gate}`);
+          }
           if (job.lastRun) {
             lines.push(`  ${theme.fg("dim", "Last run:")} ${job.lastRun}`);
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,8 @@ export interface CronJob {
   schedule: string;
   /** The prompt to execute */
   prompt: string;
+  /** Optional gate command that must exit with 0 before the prompt fires */
+  gate?: string;
   /** Whether the job is enabled */
   enabled: boolean;
   /** Type of job */
@@ -84,6 +86,12 @@ export const CronToolParams = Type.Object({
   prompt: Type.Optional(
     Type.String({
       description: "Required for add. The prompt text to execute",
+    })
+  ),
+  gate: Type.Optional(
+    Type.String({
+      description:
+        "Optional gate command. If provided, the scheduled prompt only fires when this command exits with 0. Relative executable paths are resolved against the current working directory.",
     })
   ),
   jobId: Type.Optional(


### PR DESCRIPTION
Sometimes I want to schedule work that should be gated behind a script.

<img width="1512" height="982" alt="Screenshot 2026-03-14 at 00 25 47" src="https://github.com/user-attachments/assets/6bc0e46c-143f-468b-89df-b3589f4c8639" />

```
$ cat /tmp/exit0.sh
#!/usr/bin/env bash
exit 0

$ cat /tmp/exit1.sh
#!/usr/bin/env python3
import sys
sys.exit(1)
```

For example I might not want to run a cron job if there are unstaged changes. Easy enough to figure that out with a script and unnecessary to have a tool call and send over to the LLM.