### PR TITLE
fix: scheduler leak causes duplicate job fires + runCount never advances

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,12 @@ export default async function (pi: ExtensionAPI) {
   // --- Session initialization ---
 
   const initializeSession = (ctx: any) => {
-    // Create storage and scheduler
+    // Idempotent: tear down any prior instance before creating a new one.
+    // Without this, every `session_start` (fires on reload/resume/fork too, not
+    // only on fresh startup) leaks a live croner timer into the event loop,
+    // accumulating duplicate fires for every recurring job over time.
+    cleanupSession(ctx);
+
     storage = new CronStorage(ctx.cwd);
     scheduler = new CronScheduler(storage, pi);
     widget = new CronWidget(storage, scheduler, pi, () => widgetVisible);
@@ -92,19 +97,16 @@ export default async function (pi: ExtensionAPI) {
 
   // --- Lifecycle events ---
 
+  // `session_start` fires with reason ∈ {startup, reload, new, resume, fork},
+  // so it covers all the cases where state needs to be (re)initialised. The
+  // idempotent `initializeSession` above tears down the prior scheduler before
+  // creating a new one, so we no longer need separate switch/fork handlers —
+  // and their previous event names (`session_switch`, `session_fork`) were
+  // typos in the first place: the real pi events are `session_before_switch`
+  // and `session_before_fork`, which fire *before* the switch completes and
+  // are therefore not the right point to reinitialise anyway.
+
   pi.on("session_start", async (_event, ctx) => {
-    initializeSession(ctx);
-  });
-
-  pi.on("session_switch", async (_event, ctx) => {
-    autoCleanupDisabledJobs();
-    cleanupSession(ctx);
-    initializeSession(ctx);
-  });
-
-  pi.on("session_fork", async (_event, ctx) => {
-    autoCleanupDisabledJobs();
-    cleanupSession(ctx);
     initializeSession(ctx);
   });
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -186,12 +186,20 @@ export class CronScheduler {
       // Then send the actual prompt to the agent
       this.pi.sendUserMessage(job.prompt, { deliverAs: "followUp" });
 
-      // Update job execution stats
+      // Update job execution stats.
+      //
+      // `job` here is captured by the croner closure in `scheduleJob` and is
+      // therefore frozen at the value it had when the scheduler was created —
+      // reading `job.runCount` yields a stale count, so incrementing it writes
+      // the same value to storage on every fire and the counter never advances.
+      // Re-read from storage to get the latest known count.
       const nextRun = this.getNextRun(job.id);
+      const latest = this.storage.getJob(job.id);
+      const currentRunCount = latest?.runCount ?? job.runCount;
       this.storage.updateJob(job.id, {
         lastRun: new Date().toISOString(),
         lastStatus: "success",
-        runCount: job.runCount + 1,
+        runCount: currentRunCount + 1,
         nextRun: nextRun?.toISOString(),
       });
 


### PR DESCRIPTION
# fix: scheduler leak causes duplicate job fires + runCount never advances

## Summary

Two bugs in `pi-schedule-prompt` that compound in long-lived pi sessions:

1. **Scheduler leak** — every `session_start` (which fires on `reload` / `resume` / `fork`, not only startup) creates a new `CronScheduler` without stopping the previous one, so the old croner timers stay live in the event loop. A session that has been `/reload`ed N times ends up with N+1 schedulers, and each of them fires the same recurring job at its next scheduled time → one configured daily prompt gets delivered N+1 times in a ~few-minute burst.

2. **`runCount` never advances** — `scheduleJob` captures `job` by reference into the croner callback, so `executeJob`'s `runCount: job.runCount + 1` reads the stale snapshot from scheduler startup. Every fire writes the same value, leaving the counter effectively frozen.

Both fixes are small and independent; split into one commit each.

## Root cause — bug 1

`src/index.ts` had two problems:

```ts
// Listener for a non-existent event name (silently never fires):
pi.on("session_switch", async (_event, ctx) => {
  autoCleanupDisabledJobs();
  cleanupSession(ctx);
  initializeSession(ctx);
});
pi.on("session_fork", async (_event, ctx) => { /* same, also never fires */ });
```

Pi's `ExtensionEvent` union has `session_before_switch` and `session_before_fork`, not `session_switch` / `session_fork`, so both handlers were dead code. And because they fire *before* the switch happens, they wouldn't have been the right hook for reinitialising anyway.

Meanwhile `initializeSession` was not idempotent:

```ts
const initializeSession = (ctx) => {
  storage = new CronStorage(ctx.cwd);       // overwrites reference
  scheduler = new CronScheduler(storage, pi); // old scheduler leaks
  widget = new CronWidget(...);              // old widget leaks
  scheduler.start();
};
```

So every time `session_start` fired with reason ∈ {reload, new, resume, fork}, a fresh scheduler was registered with croner but the old one stayed alive.

**Fix:** make `initializeSession` idempotent (call `cleanupSession(ctx)` at the top). Since `session_start` covers all the re-initialisation reasons, the dead `session_switch` / `session_fork` handlers can just be removed.

## Root cause — bug 2

`src/scheduler.ts:93`:

```ts
const cron = new Cron(job.schedule, () => {
  this.executeJob(job);   // `job` captured once, value frozen
});
```

And `executeJob` at line 194:

```ts
runCount: job.runCount + 1,
```

This reads the snapshot value of `runCount` from the moment the scheduler was created, not from storage. On every fire it writes `snapshot + 1` — so if `runCount` was 2 at startup, it stays at 3 forever no matter how many times the job fires.

**Fix:** re-read from storage before incrementing.

## Reproduction (without patch)

```
1. Register a daily cron prompt via the `schedule_prompt` tool.
2. Inside the same pi session, run `/reload` N times before the next fire.
3. At the scheduled time, observe N+1 `scheduled_prompt` markers + user
   messages injected into the session within a 1-2min window (interval ~10s
   between them from event-loop jitter + sendUserMessage queueing).
4. Observe `runCount` in `~/.pi/schedule-prompts.json` has only advanced
   by 1, not by N+1.
```

Real-world hit: a `telepi` / `larkpi` bridge holds one pi session per chat_id across multiple days. Over a 4-day single session with ~12 accumulated reloads, a daily 10:00 job fired 12 times between 10:00:00 and 10:04:00. `runCount` still showed 3 (the count from the first startup + 1 successful write).

## Testing

The repo has no tests, but:

- `npx tsc --noEmit` passes against the existing `tsconfig.json`.
- Manually replacing `~/.npm-global/lib/node_modules/pi-schedule-prompt` with the patched version, then `/reload`ing a session several times before a recurring cron fires → only one delivery at fire time. `runCount` now advances by 1 per fire as expected.

## Commits

- `fix: stop leaking croner timers on every session_start`
- `fix: runCount never advances — closure-captured job stays stale`
