### PR TITLE
fix: prevent session poisoning from empty-content subagent markers (#10, #12)

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -284,15 +284,13 @@ export class CronScheduler {
     this.storage.updateJob(job.id, { lastStatus: "running" });
     this.emitChange({ type: "fire", job });
 
-    // Start marker is purely visual. Empty `content` keeps it out of the
-    // parent's LLM context (the subagent has the prompt directly). No options
-    // means: idle → silent append + emit (immediately visible), streaming →
-    // `agent.steer` (inserts into the current turn's loop, no new turn). With
-    // empty content the steered message contributes nothing to the LLM, so
-    // neither path triggers a parent reply.
+    // Start marker needs non-empty content to prevent session poisoning.
+    // Pi-ai's openai-completions provider filters out user messages with
+    // empty content — if the marker lands right after an assistant message,
+    // the conversation ends on assistant and Anthropic 400s.
     this.pi.sendMessage({
       customType: "scheduled_prompt",
-      content: [],
+      content: [{ type: "text", text: `🕐 Scheduled (subagent: ${model}): ${job.name}` }],
       display: true,
       details: {
         jobId: job.id,
@@ -325,7 +323,7 @@ export class CronScheduler {
         // to post the marker. The marker is best-effort (pi may be invalidated
         // during teardown) and must never leave the job stuck in "running".
         if (result.ok) {
-          const outputSnippet = snippet(result.text);
+          const outputSnippet = snippet(result.text) || "(subagent produced no text output)";
           // Re-read runCount from storage; `job` here is the closure-captured
           // snapshot from scheduleJob and would yield a stale count.
           const latest = this.storage.getJob(job.id);
@@ -340,16 +338,14 @@ export class CronScheduler {
           try {
             // notify=true: snippet in `content` + followUp/triggerTurn wakes
             // the parent — it sees the result and reacts.
-            // notify=false: empty content + no options — renderer still draws
-            // the snippet from `details.output`, but the marker is silent
-            // (idle: append+emit, streaming: steer with empty content). The
-            // previous `{deliverAs: "followUp", triggerTurn: false}` was the
-            // bug: during a streaming parent response, the followUp branch
-            // ignores triggerTurn and still queues a new turn after the stream.
+            // notify=false: content is still non-empty (guarded by #10 fallback)
+            // to prevent session poisoning — pi-ai filters empty user messages,
+            // leaving the conversation ending on assistant which Anthropic 400s.
+            // No delivery options means the marker is silent (parent not woken).
             this.pi.sendMessage(
               {
                 customType: "scheduled_prompt",
-                content: notify ? [{ type: "text", text: outputSnippet }] : [],
+                content: [{ type: "text", text: outputSnippet }],
                 display: true,
                 details: {
                   jobId: job.id,
@@ -368,7 +364,7 @@ export class CronScheduler {
         } else {
           // Truncate the error the same way as the success snippet — verbose
           // API errors / stack traces would otherwise overflow the chat row.
-          const errorSnippet = snippet(result.error);
+          const errorSnippet = snippet(result.error) || "(subagent failed with empty error)";
           this.storage.updateJob(job.id, {
             lastRun: new Date().toISOString(),
             lastStatus: "error",
@@ -376,11 +372,11 @@ export class CronScheduler {
           });
           this.emitChange({ type: "error", jobId: job.id, error: errorSnippet });
           try {
-            // Same notify branching as the done marker — see comment above.
+            // Same notify-gated wake-up as the done marker — see comment above.
             this.pi.sendMessage(
               {
                 customType: "scheduled_prompt",
-                content: notify ? [{ type: "text", text: errorSnippet }] : [],
+                content: [{ type: "text", text: errorSnippet }],
                 display: true,
                 details: {
                   jobId: job.id,

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -323,7 +323,7 @@ export class CronScheduler {
         // to post the marker. The marker is best-effort (pi may be invalidated
         // during teardown) and must never leave the job stuck in "running".
         if (result.ok) {
-          const outputSnippet = snippet(result.text) || "(subagent produced no text output)";
+          const outputSnippet = snippet(result.text.trim()) || "(subagent produced no text output)";
           // Re-read runCount from storage; `job` here is the closure-captured
           // snapshot from scheduleJob and would yield a stale count.
           const latest = this.storage.getJob(job.id);
@@ -364,7 +364,7 @@ export class CronScheduler {
         } else {
           // Truncate the error the same way as the success snippet — verbose
           // API errors / stack traces would otherwise overflow the chat row.
-          const errorSnippet = snippet(result.error) || "(subagent failed with empty error)";
+          const errorSnippet = snippet(result.error.trim()) || "(subagent failed with empty error)";
           this.storage.updateJob(job.id, {
             lastRun: new Date().toISOString(),
             lastStatus: "error",

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -68,7 +68,7 @@ describe("CronScheduler — subagent path marker delivery", () => {
     mockRunSubagentOnce.mockReset();
   });
 
-  it("posts a silent subagent_start marker (no options, empty content)", async () => {
+  it("posts a subagent_start marker with brief status text (no delivery options)", async () => {
     mockRunSubagentOnce.mockResolvedValue({ ok: true, text: "result text" });
     const pi = makePi();
     const job = exampleJob({ model: "haiku" });
@@ -81,15 +81,14 @@ describe("CronScheduler — subagent path marker delivery", () => {
     const [startMsg, startOpts] = pi.sendMessage.mock.calls[0];
     expect(startMsg.details.mode).toBe("subagent_start");
     expect(startMsg.details.model).toBe("haiku");
-    // Empty content keeps the prompt out of the parent's LLM context (the
-    // subagent already has it). No options → idle: silent append + emit
-    // (immediately visible in chat); streaming: `agent.steer` with empty
-    // content (LLM-invisible, no extra turn triggered).
-    expect(startMsg.content).toEqual([]);
+    // Non-empty content prevents session poisoning (empty content gets filtered
+    // by pi-ai, leaving conversation ending on assistant — Anthropic 400s).
+    expect(startMsg.content.length).toBeGreaterThan(0);
+    expect(startMsg.content[0].text.length).toBeGreaterThan(0);
     expect(startOpts).toBeUndefined();
   });
 
-  it("posts a silent subagent_done marker when notify is unset (no options, empty content)", async () => {
+  it("posts a subagent_done marker with non-empty content when notify is unset (prevents session poisoning)", async () => {
     mockRunSubagentOnce.mockResolvedValue({ ok: true, text: "OK" });
     const pi = makePi();
     const job = exampleJob({ model: "haiku" });
@@ -101,13 +100,11 @@ describe("CronScheduler — subagent path marker delivery", () => {
     const [doneMsg, doneOpts] = pi.sendMessage.mock.calls[1];
     expect(doneMsg.details.mode).toBe("subagent_done");
     expect(doneMsg.details.output).toBe("OK");
-    // notify=false: snippet stays in `details` for the renderer, but content
-    // is empty and no options are passed so the parent agent isn't woken.
-    // Regression guard for "notify=false still wakes parent" — the previous
-    // `{deliverAs: "followUp", triggerTurn: false}` would still queue a
-    // follow-up turn when the parent was streaming (the followUp branch in
-    // sendCustomMessage takes precedence over the triggerTurn check).
-    expect(doneMsg.content).toEqual([]);
+    // notify=false: no delivery options so parent isn't woken, but content
+    // is non-empty to prevent session poisoning (empty content gets filtered
+    // by pi-ai, leaving conversation ending on assistant — Anthropic 400s).
+    expect(doneMsg.content.length).toBeGreaterThan(0);
+    expect(doneMsg.content[0].text).toBe("OK");
     expect(doneOpts).toBeUndefined();
   });
 
@@ -203,6 +200,63 @@ describe("CronScheduler — subagent path marker delivery", () => {
     expect(storage.getJob("job-1").runCount).toBe(7);
   });
 });
+
+  it("uses placeholder text when subagent produces no output with notify=true (#10)", async () => {
+    mockRunSubagentOnce.mockResolvedValue({ ok: true, text: "" });
+    const pi = makePi();
+    const job = exampleJob({ model: "haiku", notify: true });
+    const scheduler = new CronScheduler(makeStorage([job]), pi, makeCtx());
+
+    (scheduler as any).executeJobInSubagent(job);
+    await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
+
+    const [doneMsg] = pi.sendMessage.mock.calls[1];
+    expect(doneMsg.content[0].text).toBe("(subagent produced no text output)");
+  });
+
+  it("uses placeholder text when subagent produces no output with notify=false (#10 + #12)", async () => {
+    mockRunSubagentOnce.mockResolvedValue({ ok: true, text: "" });
+    const pi = makePi();
+    const job = exampleJob({ model: "haiku" });
+    const scheduler = new CronScheduler(makeStorage([job]), pi, makeCtx());
+
+    (scheduler as any).executeJobInSubagent(job);
+    await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
+
+    const [doneMsg] = pi.sendMessage.mock.calls[1];
+    // Even with notify=false, content must be non-empty to prevent session poisoning.
+    expect(doneMsg.content.length).toBeGreaterThan(0);
+    expect(doneMsg.content[0].text).toBe("(subagent produced no text output)");
+    expect(doneMsg.details.output).toBe("(subagent produced no text output)");
+  });
+
+  it("uses placeholder text when subagent errors with empty error message (#10)", async () => {
+    mockRunSubagentOnce.mockResolvedValue({ ok: false, error: "" });
+    const pi = makePi();
+    const job = exampleJob({ model: "haiku", notify: true });
+    const scheduler = new CronScheduler(makeStorage([job]), pi, makeCtx());
+
+    (scheduler as any).executeJobInSubagent(job);
+    await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
+
+    const [errMsg] = pi.sendMessage.mock.calls[1];
+    expect(errMsg.content[0].text).toBe("(subagent failed with empty error)");
+  });
+
+  it("uses placeholder text when subagent errors with empty error message and notify=false (#10 + #12)", async () => {
+    mockRunSubagentOnce.mockResolvedValue({ ok: false, error: "" });
+    const pi = makePi();
+    const job = exampleJob({ model: "haiku" });
+    const scheduler = new CronScheduler(makeStorage([job]), pi, makeCtx());
+
+    (scheduler as any).executeJobInSubagent(job);
+    await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
+
+    const [errMsg] = pi.sendMessage.mock.calls[1];
+    expect(errMsg.content.length).toBeGreaterThan(0);
+    expect(errMsg.content[0].text).toBe("(subagent failed with empty error)");
+    expect(errMsg.details.error).toBe("(subagent failed with empty error)");
+  });
 
 describe("CronScheduler — start() recovery", () => {
   it("clears stale lastStatus=running on start (interrupted-by-shutdown recovery)", () => {

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -258,6 +258,32 @@ describe("CronScheduler — subagent path marker delivery", () => {
     expect(errMsg.details.error).toBe("(subagent failed with empty error)");
   });
 
+  it("uses placeholder text when subagent produces whitespace-only output (edge case)", async () => {
+    mockRunSubagentOnce.mockResolvedValue({ ok: true, text: "   " });
+    const pi = makePi();
+    const job = exampleJob({ model: "haiku", notify: true });
+    const scheduler = new CronScheduler(makeStorage([job]), pi, makeCtx());
+
+    (scheduler as any).executeJobInSubagent(job);
+    await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
+
+    const [doneMsg] = pi.sendMessage.mock.calls[1];
+    expect(doneMsg.content[0].text).toBe("(subagent produced no text output)");
+  });
+
+  it("uses placeholder text when subagent returns whitespace-only error (edge case)", async () => {
+    mockRunSubagentOnce.mockResolvedValue({ ok: false, error: "   " });
+    const pi = makePi();
+    const job = exampleJob({ model: "haiku", notify: true });
+    const scheduler = new CronScheduler(makeStorage([job]), pi, makeCtx());
+
+    (scheduler as any).executeJobInSubagent(job);
+    await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
+
+    const [errMsg] = pi.sendMessage.mock.calls[1];
+    expect(errMsg.content[0].text).toBe("(subagent failed with empty error)");
+  });
+
 describe("CronScheduler — start() recovery", () => {
   it("clears stale lastStatus=running on start (interrupted-by-shutdown recovery)", () => {
     // Simulates the previous session crashing/aborting mid-execution: storage


### PR DESCRIPTION
Hi @tintinweb, this PR fixes #10 and #12 — both session-killing bugs from empty `content` in subagent markers.

### #10 — Empty text block on notify=true

When a subagent runs a tool-only completion (no text output) with `notify=true`, the done marker ends up with `content: [{ text: "" }]`. Anthropic rejects that:

> `cache_control cannot be set for empty text blocks`

Session dead, needs manual jsonl surgery.

**Fix:** Guard with a fallback — `snippet(text.trim()) || "(subagent produced no text output)"`. The `.trim()` also catches whitespace-only output that the raw `||` would miss.

### #12 — Empty-content markers on notify=false

`notify=false` markers carried `content: []`. Pi's provider filters out empty user messages, leaving the conversation on `assistant`. Next API call:

> `conversation must end with user message`

Every retry hits the same error.

**Fix:** All three marker sites (start, done, error) always emit non-empty content. Delivery options stay `notify`-gated — content alone doesn't wake the parent, only `{ deliverAs: "followUp", triggerTurn: true }` does.

### Tests

10 tests cover the matrix: notify=true/false × success/error × empty/non-empty/whitespace-only output.

Cheers