### PR TITLE
feat: add extensions and skills fields for subagent jobs (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Per-job `extensions` and `skills` fields on subagent jobs (closes #13). Each accepts `boolean | string[]`: `true` loads all registered extensions/skills, an array loads only the named ones, and unset or an empty array loads none (default — current behavior unchanged). Plumbed from the `schedule_prompt` `add`/`update` tool params through `CronJob` to `runSubagentOnce`, which drives `noExtensions`/`noSkills` and `extensionsOverride`/`skillsOverride` on the resource loader
+- Enabling `extensions` also switches the subagent from the default builtin toolset to the full set (`tools: undefined`) and calls `session.bindExtensions()` — both are required for extension-provided tools to activate (e.g. MCP, Telegram). `skills` does not widen the toolset: skills surface via the system prompt and the `read` tool. Both fields are no-ops for inline (no-model) jobs
+
+### Fixed
+- Widget no longer crashes rendering a job with an undefined `runCount` (now defaults to `0`)
+
 ## [0.4.0] - 2026-05-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ The widget displays below your editor (only when jobs exist):
 | `description` | string | no | Free-form note |
 | `model` | non-empty string | no | If set, run the prompt in a fresh in-process agent session with this model instead of injecting into the current chat. Accepts fuzzy names (`haiku`, `sonnet`) or `provider/model-id`. To switch a job from subagent back to inline mode, remove and re-add it without `model` (no in-place clearing) |
 | `notify` | boolean | no | Subagent-only. If `true`, the parent agent is woken to react to the subagent's result. Default `false` (result shown in chat, parent not interrupted). No-op for inline (no-model) jobs — the prompt itself already wakes the parent. Recommended only for low-frequency jobs |
-| `allowExtensions` | boolean | no | Subagent-only. If `true`, the subagent loads extensions (Telegram, MCP tools). Skills are also loaded. Default `false`. No-op for inline (no-model) jobs |
+| `allowExtensions` | boolean | no | Subagent-only. If `true`, the subagent loads extensions (Telegram, MCP tools). Default `false`. No-op for inline (no-model) jobs |
+| `allowSkills` | boolean | no | Subagent-only. If `true`, the subagent loads skills. Default `false`. No-op for inline (no-model) jobs |
 
 ### Schedule Formats
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The widget displays below your editor (only when jobs exist):
 | `description` | string | no | Free-form note |
 | `model` | non-empty string | no | If set, run the prompt in a fresh in-process agent session with this model instead of injecting into the current chat. Accepts fuzzy names (`haiku`, `sonnet`) or `provider/model-id`. To switch a job from subagent back to inline mode, remove and re-add it without `model` (no in-place clearing) |
 | `notify` | boolean | no | Subagent-only. If `true`, the parent agent is woken to react to the subagent's result. Default `false` (result shown in chat, parent not interrupted). No-op for inline (no-model) jobs — the prompt itself already wakes the parent. Recommended only for low-frequency jobs |
-| `allowExtensions` | boolean | no | Subagent-only. If `true`, the subagent can load extensions (Telegram, MCP tools) and skills. Default `false`. No-op for inline (no-model) jobs |
+| `allowExtensions` | boolean | no | Subagent-only. If `true`, the subagent loads extensions (Telegram, MCP tools). Skills are also loaded. Default `false`. No-op for inline (no-model) jobs |
 
 ### Schedule Formats
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,14 @@
 
 A "Heartbeat" like prompt scheduling [Pi](https://pi.dev) extension that allows the Agent to self-schedule future prompts to execute at specific times or intervals - for reminders, deferred tasks, and recurring automation.
 
-
 <img width="600"  alt="image" src="https://github.com/tintinweb/pi-schedule-prompt/raw/master/media/screenshot.png" />
 
-
-
-
-https://github.com/user-attachments/assets/8c723cc4-cf3e-4b6a-abf5-85d4f46c73ba
+<https://github.com/user-attachments/assets/8c723cc4-cf3e-4b6a-abf5-85d4f46c73ba>
 
 > **Status:** Production-ready. Natural language scheduling with cron expressions, intervals, relative time, and one-shot timers.
 
 Schedule future prompts with natural language:
+
 - **"schedule 'analyze logs' every hour"** (recurring)
 - **"remind me to review PR in 30 minutes"** (one-time)
 - **"defer that task until tomorrow at 9am"** (specific time)
@@ -20,9 +17,10 @@ Schedule future prompts with natural language:
 ## Features
 
 ### Core `schedule_prompt` Tool
+
 - **Natural language scheduling**: "schedule X in 5 minutes", "every hour do Y"
 - **Multiple formats**: Cron expressions, intervals, ISO timestamps, relative time (+5m, +1h)
-- **Job types**: 
+- **Job types**:
   - **Recurring** (cron/interval) — repeats automatically
   - **One-shot** (once) — runs once then auto-disables
 - **Per-task model (optional)**: set `model` on a job to run that prompt in a separate in-process agent session — your current chat is not affected
@@ -32,7 +30,9 @@ Schedule future prompts with natural language:
 ### Use Cases
 
 #### Schedule (Recurring Tasks)
+
 Execute prompts repeatedly at set intervals:
+
 ```
 "schedule 'check build status' every 5 minutes"
 "run 'analyze metrics' every hour"
@@ -40,15 +40,17 @@ Execute prompts repeatedly at set intervals:
 ```
 
 #### Remind (One-time Notifications)
+
 Get prompted to do something once at a specific time:
+
 ```
 "remind me to review the PR in 30 minutes"
 "remind me to check deployment status in 1 hour"
 "remind me tomorrow at 9am to follow up on the issue"
 ```
 
-
 ### Enhanced Pi Features
+
 - ✓ **Live widget** below editor showing active schedules (auto-hides when empty)
 - ✓ **Human-readable display**: "every minute", "daily at 9:00" instead of raw cron expressions
 - ✓ **Status tracking**: next run, last run, execution count, errors, prompt preview
@@ -60,16 +62,19 @@ Get prompted to do something once at a specific time:
 ## Install
 
 **Option A — Install from npm:**
+
 ```bash
 pi install npm:pi-schedule-prompt
 ```
 
 **Option B — Load directly (dev):**
+
 ```bash
 pi -e ~/projects/pi-cron-schedule/src/index.ts
 ```
 
 **Option C — Install from local folder:**
+
 ```bash
 pi install ~/projects/pi-cron-schedule
 ```
@@ -118,6 +123,7 @@ The widget displays below your editor (only when jobs exist):
 | `description` | string | no | Free-form note |
 | `model` | non-empty string | no | If set, run the prompt in a fresh in-process agent session with this model instead of injecting into the current chat. Accepts fuzzy names (`haiku`, `sonnet`) or `provider/model-id`. To switch a job from subagent back to inline mode, remove and re-add it without `model` (no in-place clearing) |
 | `notify` | boolean | no | Subagent-only. If `true`, the parent agent is woken to react to the subagent's result. Default `false` (result shown in chat, parent not interrupted). No-op for inline (no-model) jobs — the prompt itself already wakes the parent. Recommended only for low-frequency jobs |
+| `allowExtensions` | boolean | no | Subagent-only. If `true`, the subagent can load extensions (Telegram, MCP tools) and skills. Default `false`. No-op for inline (no-model) jobs |
 
 ### Schedule Formats
 
@@ -131,6 +137,7 @@ The tool accepts multiple time formats:
 | **Cron expression** | `0 */5 * * * *` | cron | Runs on cron schedule |
 
 **Cron format** (6 fields - **must include seconds**):
+
 ```
 ┌─ second (0-59)
 │ ┌─ minute (0-59)
@@ -152,6 +159,7 @@ The tool accepts multiple time formats:
 ## How It Works
 
 **Storage:**
+
 - Job data: `.pi/schedule-prompts.json` (project-local, atomic writes, auto-created)
 - Settings: two-layer config — `~/.pi/agent/schedule-prompts-settings.json` (global, hand-edited defaults) and `<cwd>/.pi/schedule-prompts-settings.json` (project, written by the UI). Project overrides global on load.
 
@@ -164,22 +172,26 @@ Toggle the default for new jobs in `/schedule-prompt → Settings → Bind new j
 **Heads up:** schedules only fire while a pi session is open in this directory; nothing is queued. A `daily 9am` cron only fires on days at least one pi is open at 9am.
 
 **Scheduler:**
+
 - Uses `croner` library for cron expressions
 - Native `setTimeout`/`setInterval` for intervals and one-shots
 - Tracks: next run, last run, execution count, status (running/success/error)
 
 **Execution:**
+
 - Sends scheduled prompt as user message to Pi agent
 - Displays custom message showing what was triggered
 - Updates job statistics after each run
 
 **Safety:**
+
 - **Infinite loop prevention**: Blocks scheduled jobs from creating more schedules
 - **Past timestamp detection**: Auto-disables jobs scheduled in the past
 - **Duplicate names**: Prevents name collisions
 - **Auto-cleanup**: Removes disabled jobs on exit
 
 **Widget:**
+
 - Auto-hides when no jobs configured
 - Shows: status icon, name, schedule (human-readable), prompt (truncated), next run, last run, run count
 - Human-readable formatting: "every minute", "daily", "Feb 13 15:30" instead of raw cron/ISO
@@ -190,6 +202,7 @@ Toggle the default for new jobs in `/schedule-prompt → Settings → Bind new j
 ## Examples
 
 ### One-time reminders
+
 ```
 "remind me to check logs in 5 minutes"
   → schedule="+5m", type=once
@@ -199,6 +212,7 @@ Toggle the default for new jobs in `/schedule-prompt → Settings → Bind new j
 ```
 
 ### Recurring tasks
+
 ```
 "analyze error rates every 10 minutes"
   → schedule="10m", type=interval
@@ -214,6 +228,7 @@ Toggle the default for new jobs in `/schedule-prompt → Settings → Bind new j
 ```
 
 ### Heartbeat monitoring
+
 ```
 "check system health every 5 minutes"
   → schedule="5m", type=interval
@@ -240,16 +255,19 @@ By default the result is shown in chat but the parent agent is **not** woken up 
 ## Development
 
 **TypeScript check:**
+
 ```bash
 npx tsc --noEmit
 ```
 
 **Run the test suite (vitest):**
+
 ```bash
 npm test
 ```
 
 **Test with Pi:**
+
 ```bash
 pi -e ./src/index.ts
 ```

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ The widget displays below your editor (only when jobs exist):
 | `description` | string | no | Free-form note |
 | `model` | non-empty string | no | If set, run the prompt in a fresh in-process agent session with this model instead of injecting into the current chat. Accepts fuzzy names (`haiku`, `sonnet`) or `provider/model-id`. To switch a job from subagent back to inline mode, remove and re-add it without `model` (no in-place clearing) |
 | `notify` | boolean | no | Subagent-only. If `true`, the parent agent is woken to react to the subagent's result. Default `false` (result shown in chat, parent not interrupted). No-op for inline (no-model) jobs — the prompt itself already wakes the parent. Recommended only for low-frequency jobs |
-| `allowExtensions` | boolean | no | Subagent-only. If `true`, the subagent loads extensions (Telegram, MCP tools). Default `false`. No-op for inline (no-model) jobs |
-| `allowSkills` | boolean | no | Subagent-only. If `true`, the subagent loads skills. Default `false`. No-op for inline (no-model) jobs |
+| `extensions` | boolean or string[] | no | Subagent-only. If `true`, loads all registered extensions. If an array of package names, only those extensions. Default `false`. No-op for inline (no-model) jobs |
+| `skills` | boolean or string[] | no | Subagent-only. If `true`, loads all skills. If an array of skill names, only those skills. Default `false`. No-op for inline (no-model) jobs |
 
 ### Schedule Formats
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ The widget displays below your editor (only when jobs exist):
 | `description` | string | no | Free-form note |
 | `model` | non-empty string | no | If set, run the prompt in a fresh in-process agent session with this model instead of injecting into the current chat. Accepts fuzzy names (`haiku`, `sonnet`) or `provider/model-id`. To switch a job from subagent back to inline mode, remove and re-add it without `model` (no in-place clearing) |
 | `notify` | boolean | no | Subagent-only. If `true`, the parent agent is woken to react to the subagent's result. Default `false` (result shown in chat, parent not interrupted). No-op for inline (no-model) jobs — the prompt itself already wakes the parent. Recommended only for low-frequency jobs |
-| `extensions` | boolean or string[] | no | Subagent-only. If `true`, loads all registered extensions. If an array of package names, only those extensions. Default `false`. No-op for inline (no-model) jobs |
-| `skills` | boolean or string[] | no | Subagent-only. If `true`, loads all skills. If an array of skill names, only those skills. Default `false`. No-op for inline (no-model) jobs |
+| `extensions` | boolean or string[] | no | Subagent-only. If `true`, loads all registered extensions; an array of package names loads only those. Unset or empty array = none (default). Enabling extensions also grants the subagent the full builtin toolset (not just the default read/write/bash set) — required for extension-provided tools to activate. No-op for inline (no-model) jobs |
+| `skills` | boolean or string[] | no | Subagent-only. If `true`, loads all skills; an array of skill names loads only those. Unset or empty array = none (default). No-op for inline (no-model) jobs |
 
 ### Schedule Formats
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -310,7 +310,7 @@ export class CronScheduler {
       try {
         let result: SubagentResult;
         try {
-          result = await runSubagentOnce(this.ctx, job.prompt, model, controller.signal, { allowExtensions: job.allowExtensions === true, allowSkills: job.allowSkills === true });
+          result = await runSubagentOnce(this.ctx, job.prompt, model, controller.signal, { extensions: job.extensions === true || Array.isArray(job.extensions) ? job.extensions : (job.extensions ? true : false), skills: job.skills === true || Array.isArray(job.skills) ? job.skills : (job.skills ? true : false) });
         } finally {
           this.activeSubagents.delete(controller);
         }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -310,7 +310,7 @@ export class CronScheduler {
       try {
         let result: SubagentResult;
         try {
-          result = await runSubagentOnce(this.ctx, job.prompt, model, controller.signal, { allowExtensions: job.allowExtensions === true });
+          result = await runSubagentOnce(this.ctx, job.prompt, model, controller.signal, { allowExtensions: job.allowExtensions === true, allowSkills: job.allowSkills === true });
         } finally {
           this.activeSubagents.delete(controller);
         }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -310,7 +310,7 @@ export class CronScheduler {
       try {
         let result: SubagentResult;
         try {
-          result = await runSubagentOnce(this.ctx, job.prompt, model, controller.signal);
+          result = await runSubagentOnce(this.ctx, job.prompt, model, controller.signal, { allowExtensions: job.allowExtensions === true });
         } finally {
           this.activeSubagents.delete(controller);
         }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -310,7 +310,7 @@ export class CronScheduler {
       try {
         let result: SubagentResult;
         try {
-          result = await runSubagentOnce(this.ctx, job.prompt, model, controller.signal, { extensions: job.extensions === true || Array.isArray(job.extensions) ? job.extensions : (job.extensions ? true : false), skills: job.skills === true || Array.isArray(job.skills) ? job.skills : (job.skills ? true : false) });
+          result = await runSubagentOnce(this.ctx, job.prompt, model, controller.signal, { extensions: job.extensions, skills: job.skills });
         } finally {
           this.activeSubagents.delete(controller);
         }

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -24,6 +24,11 @@ export type SubagentResult =
   | { ok: true; text: string }
   | { ok: false; error: string };
 
+export interface RunSubagentOptions {
+  /** If true, load extensions and skills in the subagent. Default false. */
+  allowExtensions?: boolean;
+}
+
 export function resolveModel(
   registry: ExtensionContext["modelRegistry"],
   modelStr: string,
@@ -85,6 +90,7 @@ export async function runSubagentOnce(
   prompt: string,
   modelStr: string,
   signal?: AbortSignal,
+  options: RunSubagentOptions = {},
 ): Promise<SubagentResult> {
   try {
     const model = resolveModel(ctx.modelRegistry, modelStr);
@@ -103,8 +109,10 @@ export async function runSubagentOnce(
       // recursively into the subagent and starting another scheduler.
       // Context files (AGENTS.md / CLAUDE.md) are loaded by the loader's defaults
       // so the subagent picks up project conventions.
-      noExtensions: true,
-      noSkills: true,
+      // When allowExtensions is true, extensions and skills are loaded so the
+      // subagent has access to Telegram, MCP tools, skill files, etc.
+      noExtensions: !options.allowExtensions,
+      noSkills: !options.allowExtensions,
       noPromptTemplates: true,
       noThemes: true,
     });
@@ -117,10 +125,13 @@ export async function runSubagentOnce(
       settingsManager: SettingsManager.create(ctx.cwd, agentDir),
       modelRegistry: ctx.modelRegistry,
       model,
-      tools: DEFAULT_TOOL_NAMES,
+      tools: options.allowExtensions ? undefined : DEFAULT_TOOL_NAMES,
       resourceLoader: loader,
     });
 
+    if (options.allowExtensions) {
+      await session.bindExtensions({});
+    }
     let onAbort: (() => void) | undefined;
     if (signal) {
       if (signal.aborted) {

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -105,11 +105,12 @@ export async function runSubagentOnce(
 
     const agentDir = getAgentDir();
 
-    // Helper: convert extensions/skills option to boolean and optionally filter
+    // Helper: convert extensions/skills option to boolean and optionally filter.
+    // An empty array means "none" — same as unset.
     const isEnabled = (v: boolean | string[] | undefined): boolean =>
-      v === true || Array.isArray(v);
+      v === true || (Array.isArray(v) && v.length > 0);
     const getNameList = (v: boolean | string[] | undefined): string[] | undefined =>
-      Array.isArray(v) ? v : undefined;
+      Array.isArray(v) && v.length > 0 ? v : undefined;
 
     const extList = getNameList(options.extensions);
     const skillList = getNameList(options.skills);

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -25,8 +25,10 @@ export type SubagentResult =
   | { ok: false; error: string };
 
 export interface RunSubagentOptions {
-  /** If true, load extensions and skills in the subagent. Default false. */
+  /** If true, load extensions in the subagent. Default false. */
   allowExtensions?: boolean;
+  /** If true, load skills in the subagent. Default false. */
+  allowSkills?: boolean;
 }
 
 export function resolveModel(
@@ -105,14 +107,12 @@ export async function runSubagentOnce(
     const loader = new DefaultResourceLoader({
       cwd: ctx.cwd,
       agentDir,
-      // Critical: prevent this very extension (and any other) from re-loading
-      // recursively into the subagent and starting another scheduler.
-      // Context files (AGENTS.md / CLAUDE.md) are loaded by the loader's defaults
-      // so the subagent picks up project conventions.
-      // When allowExtensions is true, extensions and skills are loaded so the
-      // subagent has access to Telegram, MCP tools, skill files, etc.
+      // Prevent recursive loading of this extension into the subagent.
+      // Context files (AGENTS.md / CLAUDE.md) are loaded by defaults.
+      // allowExtensions controls extensions (Telegram, MCP tools, etc.);
+      // allowSkills controls skill files. They are independent concerns.
       noExtensions: !options.allowExtensions,
-      noSkills: !options.allowExtensions,
+      noSkills: !options.allowSkills,
       noPromptTemplates: true,
       noThemes: true,
     });

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -25,10 +25,10 @@ export type SubagentResult =
   | { ok: false; error: string };
 
 export interface RunSubagentOptions {
-  /** If true, load extensions in the subagent. Default false. */
-  allowExtensions?: boolean;
-  /** If true, load skills in the subagent. Default false. */
-  allowSkills?: boolean;
+  /** If true, load all extensions. If an array, only those named. Default undefined (none). */
+  extensions?: boolean | string[];
+  /** If true, load all skills. If an array, only those named. Default undefined (none). */
+  skills?: boolean | string[];
 }
 
 export function resolveModel(
@@ -104,17 +104,41 @@ export async function runSubagentOnce(
     }
 
     const agentDir = getAgentDir();
+
+    // Helper: convert extensions/skills option to boolean and optionally filter
+    const isEnabled = (v: boolean | string[] | undefined): boolean =>
+      v === true || Array.isArray(v);
+    const getNameList = (v: boolean | string[] | undefined): string[] | undefined =>
+      Array.isArray(v) ? v : undefined;
+
+    const extList = getNameList(options.extensions);
+    const skillList = getNameList(options.skills);
+
     const loader = new DefaultResourceLoader({
       cwd: ctx.cwd,
       agentDir,
       // Prevent recursive loading of this extension into the subagent.
       // Context files (AGENTS.md / CLAUDE.md) are loaded by defaults.
-      // allowExtensions controls extensions (Telegram, MCP tools, etc.);
-      // allowSkills controls skill files. They are independent concerns.
-      noExtensions: !options.allowExtensions,
-      noSkills: !options.allowSkills,
+      noExtensions: !isEnabled(options.extensions),
+      noSkills: !isEnabled(options.skills),
       noPromptTemplates: true,
       noThemes: true,
+      ...(extList && {
+        extensionsOverride: (base) => ({
+          ...base,
+          extensions: base.extensions.filter((ext) =>
+            extList.some((name) => ext.path.toLowerCase().includes(name.toLowerCase())),
+          ),
+        }),
+      }),
+      ...(skillList && {
+        skillsOverride: (base) => ({
+          ...base,
+          skills: base.skills.filter((skill) =>
+            skillList.includes(skill.name || ""),
+          ),
+        }),
+      }),
     });
     await loader.reload();
 
@@ -125,11 +149,11 @@ export async function runSubagentOnce(
       settingsManager: SettingsManager.create(ctx.cwd, agentDir),
       modelRegistry: ctx.modelRegistry,
       model,
-      tools: options.allowExtensions ? undefined : DEFAULT_TOOL_NAMES,
+      tools: isEnabled(options.extensions) ? undefined : DEFAULT_TOOL_NAMES,
       resourceLoader: loader,
     });
 
-    if (options.allowExtensions) {
+    if (isEnabled(options.extensions)) {
       await session.bindExtensions({});
     }
     let onAbort: (() => void) | undefined;

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -100,8 +100,8 @@ export function createCronTool(
               description: params.description,
               model: params.model,
               notify: params.notify,
-              allowExtensions: params.allowExtensions,
-              allowSkills: params.allowSkills,
+              extensions: params.extensions,
+              skills: params.skills,
               session,
             };
 
@@ -112,7 +112,7 @@ export function createCronTool(
             details.jobName = job.name;
 
             const modelLine = job.model
-              ? `\nModel: ${job.model} (runs in subagent${job.notify ? ", notifies parent" : ""}${job.allowExtensions ? ", extensions" : ""}${job.allowSkills ? ", skills" : ""})`
+              ? `\nModel: ${job.model} (runs in subagent${job.notify ? ", notifies parent" : ""}${job.extensions ? ", extensions" : ""}${job.skills ? ", skills" : ""})`
               : "";
             return {
               content: [
@@ -249,8 +249,8 @@ export function createCronTool(
             if (params.description !== undefined) updates.description = params.description;
             if (params.model !== undefined) updates.model = params.model;
             if (params.notify !== undefined) updates.notify = params.notify;
-            if (params.allowExtensions !== undefined) updates.allowExtensions = params.allowExtensions;
-            if (params.allowSkills !== undefined) updates.allowSkills = params.allowSkills;
+            if (params.extensions !== undefined) updates.extensions = params.extensions;
+            if (params.skills !== undefined) updates.skills = params.skills;
 
             if (params.schedule) {
               // Same resolution rules as `add`: relative time (`+5m`) → ISO,
@@ -304,7 +304,7 @@ export function createCronTool(
               lines.push(`${status} ${job.name} (${job.id})`);
               lines.push(`  Type: ${job.type} | Schedule: ${job.schedule}`);
               if (job.model) {
-                lines.push(`  Model: ${job.model} (runs in subagent${job.notify ? ", notifies parent" : ""}${job.allowExtensions ? ", extensions" : ""}${job.allowSkills ? ", skills" : ""})`);
+                lines.push(`  Model: ${job.model} (runs in subagent${job.notify ? ", notifies parent" : ""}${job.extensions ? ", extensions" : ""}${job.skills ? ", skills" : ""})`);
               }
               lines.push(`  Prompt: ${job.prompt}`);
               lines.push(`  ${lastStr} ${nextStr ? `| ${nextStr}` : ""}`);
@@ -399,8 +399,8 @@ export function createCronTool(
           if (job.model) {
             const subagentTag = job.notify ? "(subagent, notifies parent)" : "(subagent)";
             const tags = [];
-            if (job.allowExtensions) tags.push("extensions");
-            if (job.allowSkills) tags.push("skills");
+            if (job.extensions) tags.push("extensions");
+            if (job.skills) tags.push("skills");
             const tagStr = tags.length ? ", " + tags.join(" + ") : "";
             lines.push(`  ${theme.fg("dim", "Model:")} ${job.model} ${theme.fg("dim", subagentTag)}${tagStr}`);
           }

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -100,6 +100,7 @@ export function createCronTool(
               description: params.description,
               model: params.model,
               notify: params.notify,
+              allowExtensions: params.allowExtensions,
               session,
             };
 
@@ -110,7 +111,7 @@ export function createCronTool(
             details.jobName = job.name;
 
             const modelLine = job.model
-              ? `\nModel: ${job.model} (runs in subagent${job.notify ? ", notifies parent" : ""})`
+              ? `\nModel: ${job.model} (runs in subagent${job.notify ? ", notifies parent" : ""}${job.allowExtensions ? ", extensions + skills" : ""})` 
               : "";
             return {
               content: [
@@ -247,6 +248,7 @@ export function createCronTool(
             if (params.description !== undefined) updates.description = params.description;
             if (params.model !== undefined) updates.model = params.model;
             if (params.notify !== undefined) updates.notify = params.notify;
+            if (params.allowExtensions !== undefined) updates.allowExtensions = params.allowExtensions;
 
             if (params.schedule) {
               // Same resolution rules as `add`: relative time (`+5m`) → ISO,
@@ -394,7 +396,8 @@ export function createCronTool(
           );
           if (job.model) {
             const subagentTag = job.notify ? "(subagent, notifies parent)" : "(subagent)";
-            lines.push(`  ${theme.fg("dim", "Model:")} ${job.model} ${theme.fg("dim", subagentTag)}`);
+            const extTag = job.allowExtensions ? ", extensions + skills" : "";
+            lines.push(`  ${theme.fg("dim", "Model:")} ${job.model} ${theme.fg("dim", subagentTag)}${extTag}`);
           }
           lines.push(`  ${theme.fg("dim", "Prompt:")} ${job.prompt}`);
           if (job.lastRun) {

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -101,6 +101,7 @@ export function createCronTool(
               model: params.model,
               notify: params.notify,
               allowExtensions: params.allowExtensions,
+              allowSkills: params.allowSkills,
               session,
             };
 
@@ -111,7 +112,7 @@ export function createCronTool(
             details.jobName = job.name;
 
             const modelLine = job.model
-              ? `\nModel: ${job.model} (runs in subagent${job.notify ? ", notifies parent" : ""}${job.allowExtensions ? ", extensions + skills" : ""})` 
+              ? `\nModel: ${job.model} (runs in subagent${job.notify ? ", notifies parent" : ""}${job.allowExtensions ? ", extensions" : ""}${job.allowSkills ? ", skills" : ""})`
               : "";
             return {
               content: [
@@ -249,6 +250,7 @@ export function createCronTool(
             if (params.model !== undefined) updates.model = params.model;
             if (params.notify !== undefined) updates.notify = params.notify;
             if (params.allowExtensions !== undefined) updates.allowExtensions = params.allowExtensions;
+            if (params.allowSkills !== undefined) updates.allowSkills = params.allowSkills;
 
             if (params.schedule) {
               // Same resolution rules as `add`: relative time (`+5m`) → ISO,
@@ -302,7 +304,7 @@ export function createCronTool(
               lines.push(`${status} ${job.name} (${job.id})`);
               lines.push(`  Type: ${job.type} | Schedule: ${job.schedule}`);
               if (job.model) {
-                lines.push(`  Model: ${job.model} (runs in subagent${job.notify ? ", notifies parent" : ""})`);
+                lines.push(`  Model: ${job.model} (runs in subagent${job.notify ? ", notifies parent" : ""}${job.allowExtensions ? ", extensions" : ""}${job.allowSkills ? ", skills" : ""})`);
               }
               lines.push(`  Prompt: ${job.prompt}`);
               lines.push(`  ${lastStr} ${nextStr ? `| ${nextStr}` : ""}`);
@@ -396,8 +398,11 @@ export function createCronTool(
           );
           if (job.model) {
             const subagentTag = job.notify ? "(subagent, notifies parent)" : "(subagent)";
-            const extTag = job.allowExtensions ? ", extensions + skills" : "";
-            lines.push(`  ${theme.fg("dim", "Model:")} ${job.model} ${theme.fg("dim", subagentTag)}${extTag}`);
+            const tags = [];
+            if (job.allowExtensions) tags.push("extensions");
+            if (job.allowSkills) tags.push("skills");
+            const tagStr = tags.length ? ", " + tags.join(" + ") : "";
+            lines.push(`  ${theme.fg("dim", "Model:")} ${job.model} ${theme.fg("dim", subagentTag)}${tagStr}`);
           }
           lines.push(`  ${theme.fg("dim", "Prompt:")} ${job.prompt}`);
           if (job.lastRun) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,10 +44,10 @@ export interface CronJob {
   model?: string;
   /** Subagent jobs only. If true, the parent agent is woken up to react to the subagent's result. Default false (result lands in chat silently). */
   notify?: boolean;
-  /** Subagent jobs only. If true, the subagent loads extensions (Telegram, MCP, etc.). Default false. */
-  allowExtensions?: boolean;
-  /** Subagent jobs only. If true, the subagent loads skills. Default false. */
-  allowSkills?: boolean;
+  /** Subagent jobs only. If true, loads all registered extensions. If an array of package names, only those extensions. Default undefined (none). */
+  extensions?: boolean | string[];
+  /** Subagent jobs only. If true, loads all skills. If an array of skill names, only those skills. Default undefined (none). */
+  skills?: boolean | string[];
 }
 
 /**
@@ -120,17 +120,25 @@ export const CronToolParams = Type.Object({
         "Subagent jobs only. If true, the parent agent is nudged to react to the subagent's result. Default false: the result is shown in chat but the parent is not interrupted. Ignored for inline (no-model) jobs, where the prompt itself already wakes the parent. Recommended only for low-frequency jobs.",
     })
   ),
-  allowExtensions: Type.Optional(
-    Type.Boolean({
-      description:
-        "Subagent jobs only. If true, the subagent loads extensions (Telegram, MCP, etc.). Default false.",
-    })
+  extensions: Type.Optional(
+    Type.Union([
+      Type.Boolean({
+        description: "If true, loads all registered extensions.",
+      }),
+      Type.Array(Type.String(), {
+        description: "List of extension package names to load.",
+      }),
+    ])
   ),
-  allowSkills: Type.Optional(
-    Type.Boolean({
-      description:
-        "Subagent jobs only. If true, the subagent loads skills. Default false.",
-    })
+  skills: Type.Optional(
+    Type.Union([
+      Type.Boolean({
+        description: "If true, loads all skills.",
+      }),
+      Type.Array(Type.String(), {
+        description: "List of skill names to load.",
+      }),
+    ])
   ),
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,8 @@ export interface CronJob {
   extensions?: boolean | string[];
   /** Subagent jobs only. If true, loads all skills. If an array of skill names, only those skills. Default undefined (none). */
   skills?: boolean | string[];
+  /** Session id this job is bound to. When absent, every pi in the cwd loads it. */
+  session?: string;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,8 @@ export interface CronJob {
   model?: string;
   /** Subagent jobs only. If true, the parent agent is woken up to react to the subagent's result. Default false (result lands in chat silently). */
   notify?: boolean;
+  /** Subagent jobs only. If true, the subagent loads extensions (Telegram, MCP, etc.) and skills, making all tools available. Default false. */
+  allowExtensions?: boolean;
   /** Session id this job is bound to. When absent, every pi in the cwd loads it. */
   session?: string;
 }
@@ -116,6 +118,12 @@ export const CronToolParams = Type.Object({
     Type.Boolean({
       description:
         "Subagent jobs only. If true, the parent agent is nudged to react to the subagent's result. Default false: the result is shown in chat but the parent is not interrupted. Ignored for inline (no-model) jobs, where the prompt itself already wakes the parent. Recommended only for low-frequency jobs.",
+    })
+  ),
+  allowExtensions: Type.Optional(
+    Type.Boolean({
+      description:
+        "Subagent jobs only. If true, the subagent loads extensions (Telegram, MCP, etc.) and skills, making all tools available. Default false.",
     })
   ),
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,10 +44,10 @@ export interface CronJob {
   model?: string;
   /** Subagent jobs only. If true, the parent agent is woken up to react to the subagent's result. Default false (result lands in chat silently). */
   notify?: boolean;
-  /** Subagent jobs only. If true, the subagent loads extensions (Telegram, MCP, etc.) and skills, making all tools available. Default false. */
+  /** Subagent jobs only. If true, the subagent loads extensions (Telegram, MCP, etc.). Default false. */
   allowExtensions?: boolean;
-  /** Session id this job is bound to. When absent, every pi in the cwd loads it. */
-  session?: string;
+  /** Subagent jobs only. If true, the subagent loads skills. Default false. */
+  allowSkills?: boolean;
 }
 
 /**
@@ -123,7 +123,13 @@ export const CronToolParams = Type.Object({
   allowExtensions: Type.Optional(
     Type.Boolean({
       description:
-        "Subagent jobs only. If true, the subagent loads extensions (Telegram, MCP, etc.) and skills, making all tools available. Default false.",
+        "Subagent jobs only. If true, the subagent loads extensions (Telegram, MCP, etc.). Default false.",
+    })
+  ),
+  allowSkills: Type.Optional(
+    Type.Boolean({
+      description:
+        "Subagent jobs only. If true, the subagent loads skills. Default false.",
     })
   ),
 });

--- a/src/ui/cron-widget.ts
+++ b/src/ui/cron-widget.ts
@@ -182,7 +182,7 @@ export class CronWidget {
       const lastText = job.lastRun ? lastPadded : theme.fg("dim", lastPadded);
 
       // Run count (pad to 3 chars for alignment)
-      const countText = theme.fg("accent", job.runCount.toString().padEnd(3));
+      const countText = theme.fg("accent", (job.runCount ?? 0).toString().padEnd(3));
 
       // Model badge (only for jobs that run in a subagent).
       // Trailing "!" marks jobs that wake the parent agent on completion (notify=true).

--- a/test/cron-widget.test.ts
+++ b/test/cron-widget.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { CronWidget } from "../src/ui/cron-widget.js";
-import type { CronStorage } from "../src/storage.js";
-import type { CronScheduler } from "../src/scheduler.js";
-import type { CronJob } from "../src/types.js";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import type { CronScheduler } from "../src/scheduler.js";
+import type { CronStorage } from "../src/storage.js";
+import type { CronJob } from "../src/types.js";
+import { CronWidget } from "../src/ui/cron-widget.js";
 
 function makeStorage(jobs: CronJob[]): CronStorage {
   return {
@@ -15,7 +15,7 @@ function makeStorage(jobs: CronJob[]): CronStorage {
   } as any;
 }
 
-function makeScheduler(jobs: CronJob[]): CronScheduler {
+function makeScheduler(_jobs: CronJob[]): CronScheduler {
   return {
     getNextRun: vi.fn(() => null),
     isLoadedFor: vi.fn(() => true),

--- a/test/cron-widget.test.ts
+++ b/test/cron-widget.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CronWidget } from "../src/ui/cron-widget.js";
+import type { CronStorage } from "../src/storage.js";
+import type { CronScheduler } from "../src/scheduler.js";
+import type { CronJob } from "../src/types.js";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+function makeStorage(jobs: CronJob[]): CronStorage {
+  return {
+    getJob: vi.fn((id: string) => jobs.find((j) => j.id === id)),
+    getAllJobs: vi.fn(() => jobs),
+    addJob: vi.fn(),
+    removeJob: vi.fn(),
+    updateJob: vi.fn(),
+  } as any;
+}
+
+function makeScheduler(jobs: CronJob[]): CronScheduler {
+  return {
+    getNextRun: vi.fn(() => null),
+    isLoadedFor: vi.fn(() => true),
+  } as any;
+}
+
+function makePi(): ExtensionAPI {
+  return {
+    events: { on: vi.fn(() => () => {}) },
+  } as any;
+}
+
+function makeCtx(): any {
+  return {
+    ui: {
+      setWidget: vi.fn(),
+    },
+  };
+}
+
+function exampleJob(overrides: Partial<CronJob> = {}): CronJob {
+  return {
+    id: "test-1",
+    name: "Test Job",
+    schedule: "0 * * * * *",
+    type: "cron",
+    prompt: "say hello",
+    enabled: true,
+    ...overrides,
+  } as CronJob;
+}
+
+describe("CronWidget — render", () => {
+  it("handles jobs with undefined runCount without crashing", () => {
+    const job = exampleJob({ runCount: undefined });
+    const storage = makeStorage([job]);
+    const scheduler = makeScheduler([job]);
+    const pi = makePi();
+    const ctx = makeCtx();
+
+    const widget = new CronWidget(storage, scheduler as any, pi, () => true, "test-session");
+    widget.show(ctx);
+
+    expect(ctx.ui.setWidget).toHaveBeenCalledTimes(1);
+    const widgetFactory = ctx.ui.setWidget.mock.calls[0][1];
+    const theme = { fg: () => {}, bold: (s: string) => s, dim: (s: string) => s, error: (s: string) => s, success: (s: string) => s, warning: (s: string) => s, muted: (s: string) => s, accent: (s: string) => s, text: (s: string) => s };
+    const widgetImpl = widgetFactory(null, theme);
+    expect(() => widgetImpl.render(100)).not.toThrow();
+  });
+});

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -572,47 +572,47 @@ describe("CronScheduler.describeSchedule", () => {
   });
 });
 
-describe("CronScheduler — allowExtensions", () => {
+describe("CronScheduler — extensions/skills", () => {
   beforeEach(() => {
     mockRunSubagentOnce.mockReset();
   });
 
-  it("passes allowExtensions=true to runSubagentOnce when job has allowExtensions=true", async () => {
+  it("passes extensions=true to runSubagentOnce when job has extensions=true", async () => {
     mockRunSubagentOnce.mockResolvedValue({ ok: true, text: "OK" });
     const pi = makePi();
-    const job = exampleJob({ model: "haiku", allowExtensions: true });
+    const job = exampleJob({ model: "haiku", extensions: true });
     const scheduler = new CronScheduler(makeStorage([job]), pi, makeCtx());
 
     (scheduler as any).executeJobInSubagent(job);
     await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
 
     const options = mockRunSubagentOnce.mock.calls[0][4];
-    expect(options).toEqual({ allowExtensions: true, allowSkills: false });
+    expect(options).toEqual({ extensions: true, skills: false });
   });
 
-  it("passes allowExtensions=false to runSubagentOnce when job has no allowExtensions", async () => {
+  it("passes extensions=false to runSubagentOnce when job has no extensions", async () => {
     mockRunSubagentOnce.mockResolvedValue({ ok: true, text: "OK" });
     const pi = makePi();
-    const job = exampleJob({ model: "haiku" }); // no allowExtensions
+    const job = exampleJob({ model: "haiku" }); // no extensions
     const scheduler = new CronScheduler(makeStorage([job]), pi, makeCtx());
 
     (scheduler as any).executeJobInSubagent(job);
     await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
 
     const options = mockRunSubagentOnce.mock.calls[0][4];
-    expect(options).toEqual({ allowExtensions: false, allowSkills: false });
+    expect(options).toEqual({ extensions: false, skills: false });
   });
 
-  it("passes allowExtensions=false to runSubagentOnce when job has allowExtensions=false", async () => {
+  it("passes extensions=false to runSubagentOnce when job has extensions=false", async () => {
     mockRunSubagentOnce.mockResolvedValue({ ok: true, text: "OK" });
     const pi = makePi();
-    const job = exampleJob({ model: "haiku", allowExtensions: false });
+    const job = exampleJob({ model: "haiku", extensions: false });
     const scheduler = new CronScheduler(makeStorage([job]), pi, makeCtx());
 
     (scheduler as any).executeJobInSubagent(job);
     await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
 
     const options = mockRunSubagentOnce.mock.calls[0][4];
-    expect(options).toEqual({ allowExtensions: false, allowSkills: false });
+    expect(options).toEqual({ extensions: false, skills: false });
   });
 });

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -571,3 +571,48 @@ describe("CronScheduler.describeSchedule", () => {
     expect(out).toMatch(/^[A-Z][a-z]{2} \d{1,2} \d{2}:\d{2}$/);
   });
 });
+
+describe("CronScheduler — allowExtensions", () => {
+  beforeEach(() => {
+    mockRunSubagentOnce.mockReset();
+  });
+
+  it("passes allowExtensions=true to runSubagentOnce when job has allowExtensions=true", async () => {
+    mockRunSubagentOnce.mockResolvedValue({ ok: true, text: "OK" });
+    const pi = makePi();
+    const job = exampleJob({ model: "haiku", allowExtensions: true });
+    const scheduler = new CronScheduler(makeStorage([job]), pi, makeCtx());
+
+    (scheduler as any).executeJobInSubagent(job);
+    await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
+
+    const options = mockRunSubagentOnce.mock.calls[0][4];
+    expect(options).toEqual({ allowExtensions: true });
+  });
+
+  it("passes allowExtensions=false to runSubagentOnce when job has no allowExtensions", async () => {
+    mockRunSubagentOnce.mockResolvedValue({ ok: true, text: "OK" });
+    const pi = makePi();
+    const job = exampleJob({ model: "haiku" }); // no allowExtensions
+    const scheduler = new CronScheduler(makeStorage([job]), pi, makeCtx());
+
+    (scheduler as any).executeJobInSubagent(job);
+    await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
+
+    const options = mockRunSubagentOnce.mock.calls[0][4];
+    expect(options).toEqual({ allowExtensions: false });
+  });
+
+  it("passes allowExtensions=false to runSubagentOnce when job has allowExtensions=false", async () => {
+    mockRunSubagentOnce.mockResolvedValue({ ok: true, text: "OK" });
+    const pi = makePi();
+    const job = exampleJob({ model: "haiku", allowExtensions: false });
+    const scheduler = new CronScheduler(makeStorage([job]), pi, makeCtx());
+
+    (scheduler as any).executeJobInSubagent(job);
+    await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
+
+    const options = mockRunSubagentOnce.mock.calls[0][4];
+    expect(options).toEqual({ allowExtensions: false });
+  });
+});

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -587,7 +587,7 @@ describe("CronScheduler — allowExtensions", () => {
     await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
 
     const options = mockRunSubagentOnce.mock.calls[0][4];
-    expect(options).toEqual({ allowExtensions: true });
+    expect(options).toEqual({ allowExtensions: true, allowSkills: false });
   });
 
   it("passes allowExtensions=false to runSubagentOnce when job has no allowExtensions", async () => {
@@ -600,7 +600,7 @@ describe("CronScheduler — allowExtensions", () => {
     await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
 
     const options = mockRunSubagentOnce.mock.calls[0][4];
-    expect(options).toEqual({ allowExtensions: false });
+    expect(options).toEqual({ allowExtensions: false, allowSkills: false });
   });
 
   it("passes allowExtensions=false to runSubagentOnce when job has allowExtensions=false", async () => {
@@ -613,6 +613,6 @@ describe("CronScheduler — allowExtensions", () => {
     await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
 
     const options = mockRunSubagentOnce.mock.calls[0][4];
-    expect(options).toEqual({ allowExtensions: false });
+    expect(options).toEqual({ allowExtensions: false, allowSkills: false });
   });
 });

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -587,7 +587,7 @@ describe("CronScheduler — extensions/skills", () => {
     await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
 
     const options = mockRunSubagentOnce.mock.calls[0][4];
-    expect(options).toEqual({ extensions: true, skills: false });
+    expect(options).toEqual({ extensions: true, skills: undefined });
   });
 
   it("passes extensions=false to runSubagentOnce when job has no extensions", async () => {
@@ -600,7 +600,7 @@ describe("CronScheduler — extensions/skills", () => {
     await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
 
     const options = mockRunSubagentOnce.mock.calls[0][4];
-    expect(options).toEqual({ extensions: false, skills: false });
+    expect(options).toEqual({ extensions: undefined, skills: undefined });
   });
 
   it("passes extensions=false to runSubagentOnce when job has extensions=false", async () => {
@@ -613,6 +613,6 @@ describe("CronScheduler — extensions/skills", () => {
     await vi.waitFor(() => expect(pi.sendMessage).toHaveBeenCalledTimes(2));
 
     const options = mockRunSubagentOnce.mock.calls[0][4];
-    expect(options).toEqual({ extensions: false, skills: false });
+    expect(options).toEqual({ extensions: false, skills: undefined });
   });
 });

--- a/test/subagent.test.ts
+++ b/test/subagent.test.ts
@@ -245,12 +245,12 @@ describe("runSubagentOnce", () => {
     expect(fakeSession.bindExtensions).not.toHaveBeenCalled();
   });
 
-  it("allowExtensions:true: sets noExtensions=false, noSkills=true, tools=undefined, calls bindExtensions", async () => {
+  it("extensions:true: sets noExtensions=false, noSkills=true, tools=undefined, calls bindExtensions", async () => {
     const fakeSession = makeFakeSession();
     mockCreateAgentSession.mockResolvedValue({ session: fakeSession });
 
     const result = await runSubagentOnce(makeCtx(), "test prompt", MODELS[0].id, undefined, {
-      allowExtensions: true,
+      extensions: true,
     });
 
     expect(result.ok).toBe(true);
@@ -268,12 +268,12 @@ describe("runSubagentOnce", () => {
     expect(fakeSession.bindExtensions).toHaveBeenCalledTimes(1);
   });
 
-  it("allowSkills:true: sets noExtensions=true, noSkills=false, tools=DEFAULT_TOOL_NAMES, no bindExtensions", async () => {
+  it("skills:true: sets noExtensions=true, noSkills=false, tools=DEFAULT_TOOL_NAMES, no bindExtensions", async () => {
     const fakeSession = makeFakeSession();
     mockCreateAgentSession.mockResolvedValue({ session: fakeSession });
 
     const result = await runSubagentOnce(makeCtx(), "test prompt", MODELS[0].id, undefined, {
-      allowSkills: true,
+      skills: true,
     });
 
     expect(result.ok).toBe(true);
@@ -291,13 +291,13 @@ describe("runSubagentOnce", () => {
     expect(fakeSession.bindExtensions).not.toHaveBeenCalled();
   });
 
-  it("allowExtensions:true + allowSkills:true: sets noExtensions=false, noSkills=false, tools=undefined, calls bindExtensions", async () => {
+  it("extensions:true + skills:true: sets noExtensions=false, noSkills=false, tools=undefined, calls bindExtensions", async () => {
     const fakeSession = makeFakeSession();
     mockCreateAgentSession.mockResolvedValue({ session: fakeSession });
 
     const result = await runSubagentOnce(makeCtx(), "test prompt", MODELS[0].id, undefined, {
-      allowExtensions: true,
-      allowSkills: true,
+      extensions: true,
+      skills: true,
     });
 
     expect(result.ok).toBe(true);
@@ -313,5 +313,44 @@ describe("runSubagentOnce", () => {
 
     // bindExtensions should have been called
     expect(fakeSession.bindExtensions).toHaveBeenCalledTimes(1);
+  });
+
+  it("extensions:[\"pkg\"]: filters extensions, sets noExtensions=false, tools=undefined, calls bindExtensions", async () => {
+    const fakeSession = makeFakeSession();
+    mockCreateAgentSession.mockResolvedValue({ session: fakeSession });
+
+
+    const result = await runSubagentOnce(makeCtx(), "test prompt", MODELS[0].id, undefined, {
+      extensions: ["telegram"],
+    });
+
+    expect(result.ok).toBe(true);
+
+    const loaderOptions = mockDefaultResourceLoader.mock.calls[0][0];
+    expect(loaderOptions.noExtensions).toBe(false);
+    expect(typeof loaderOptions.extensionsOverride).toBe("function");
+
+    const sessionOptions = mockCreateAgentSession.mock.calls[0][0];
+    expect(sessionOptions.tools).toBeUndefined();
+
+    expect(fakeSession.bindExtensions).toHaveBeenCalledTimes(1);
+  });
+
+  it("skills:[\"git\"]: filters skills, sets noSkills=false", async () => {
+    const fakeSession = makeFakeSession();
+    mockCreateAgentSession.mockResolvedValue({ session: fakeSession });
+
+
+    const result = await runSubagentOnce(makeCtx(), "test prompt", MODELS[0].id, undefined, {
+      skills: ["git"],
+    });
+
+    expect(result.ok).toBe(true);
+
+    const loaderOptions = mockDefaultResourceLoader.mock.calls[0][0];
+    expect(loaderOptions.noSkills).toBe(false);
+    expect(typeof loaderOptions.skillsOverride).toBe("function");
+
+    expect(fakeSession.bindExtensions).not.toHaveBeenCalled();
   });
 });

--- a/test/subagent.test.ts
+++ b/test/subagent.test.ts
@@ -245,12 +245,59 @@ describe("runSubagentOnce", () => {
     expect(fakeSession.bindExtensions).not.toHaveBeenCalled();
   });
 
-  it("allowExtensions:true: sets noExtensions=false, noSkills=false, tools=undefined, calls bindExtensions", async () => {
+  it("allowExtensions:true: sets noExtensions=false, noSkills=true, tools=undefined, calls bindExtensions", async () => {
     const fakeSession = makeFakeSession();
     mockCreateAgentSession.mockResolvedValue({ session: fakeSession });
 
     const result = await runSubagentOnce(makeCtx(), "test prompt", MODELS[0].id, undefined, {
       allowExtensions: true,
+    });
+
+    expect(result.ok).toBe(true);
+
+    // Check DefaultResourceLoader was created with noExtensions: false, noSkills: true
+    const loaderOptions = mockDefaultResourceLoader.mock.calls[0][0];
+    expect(loaderOptions.noExtensions).toBe(false);
+    expect(loaderOptions.noSkills).toBe(true);
+
+    // Check createAgentSession was called with tools: undefined
+    const sessionOptions = mockCreateAgentSession.mock.calls[0][0];
+    expect(sessionOptions.tools).toBeUndefined();
+
+    // bindExtensions should have been called
+    expect(fakeSession.bindExtensions).toHaveBeenCalledTimes(1);
+  });
+
+  it("allowSkills:true: sets noExtensions=true, noSkills=false, tools=DEFAULT_TOOL_NAMES, no bindExtensions", async () => {
+    const fakeSession = makeFakeSession();
+    mockCreateAgentSession.mockResolvedValue({ session: fakeSession });
+
+    const result = await runSubagentOnce(makeCtx(), "test prompt", MODELS[0].id, undefined, {
+      allowSkills: true,
+    });
+
+    expect(result.ok).toBe(true);
+
+    // Check DefaultResourceLoader was created with noExtensions: true, noSkills: false
+    const loaderOptions = mockDefaultResourceLoader.mock.calls[0][0];
+    expect(loaderOptions.noExtensions).toBe(true);
+    expect(loaderOptions.noSkills).toBe(false);
+
+    // Check createAgentSession was called with tools: DEFAULT_TOOL_NAMES
+    const sessionOptions = mockCreateAgentSession.mock.calls[0][0];
+    expect(sessionOptions.tools).toEqual(["bash", "read", "edit", "write", "grep", "find", "ls"]);
+
+    // bindExtensions should NOT have been called
+    expect(fakeSession.bindExtensions).not.toHaveBeenCalled();
+  });
+
+  it("allowExtensions:true + allowSkills:true: sets noExtensions=false, noSkills=false, tools=undefined, calls bindExtensions", async () => {
+    const fakeSession = makeFakeSession();
+    mockCreateAgentSession.mockResolvedValue({ session: fakeSession });
+
+    const result = await runSubagentOnce(makeCtx(), "test prompt", MODELS[0].id, undefined, {
+      allowExtensions: true,
+      allowSkills: true,
     });
 
     expect(result.ok).toBe(true);

--- a/test/subagent.test.ts
+++ b/test/subagent.test.ts
@@ -1,9 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   describeAvailableModels,
   getLastAssistantText,
   resolveModel,
 } from "../src/subagent.js";
+import {
+  runSubagentOnce,
+} from "../src/subagent.js";
+
+// Mock the pi-coding-agent module for runSubagentOnce tests
+// Must be at file scope — vitest hoists vi.mock to the top automatically.
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+  createAgentSession: vi.fn(),
+  DefaultResourceLoader: vi.fn(function () {
+    return { reload: vi.fn().mockResolvedValue(undefined) };
+  }),
+  getAgentDir: vi.fn(() => "/tmp/agent-dir"),
+  SessionManager: { inMemory: vi.fn(() => ({ getSessionId: () => "test" })) },
+  SettingsManager: { create: vi.fn(() => ({})) },
+}));
+
+import { createAgentSession, DefaultResourceLoader } from "@earendil-works/pi-coding-agent";
+
+const mockCreateAgentSession = vi.mocked(createAgentSession);
+const mockDefaultResourceLoader = vi.mocked(DefaultResourceLoader);
 
 // Mirror of the minimal Model shape resolveModel actually touches: provider, id, name.
 const MODELS = [
@@ -172,5 +192,79 @@ describe("getLastAssistantText", () => {
         ]),
       ),
     ).toBe("real text");
+  });
+});
+
+describe("runSubagentOnce", () => {
+  beforeEach(() => {
+    mockCreateAgentSession.mockReset();
+    mockDefaultResourceLoader.mockReset();
+  });
+
+  function makeFakeSession() {
+    return {
+      abort: vi.fn(),
+      subscribe: vi.fn(() => vi.fn()),
+      prompt: vi.fn().mockResolvedValue(undefined),
+      messages: [],
+      bindExtensions: vi.fn(),
+    };
+  }
+
+  function makeCtx() {
+    return {
+      cwd: "/tmp",
+      modelRegistry: {
+        find: () => MODELS[0],
+        getAvailable: () => MODELS,
+      },
+      sessionManager: {
+        getSessionId: () => "test",
+      },
+    } as any;
+  }
+
+  it("default: creates subagent with noExtensions=true, noSkills=true, tools=DEFAULT_TOOL_NAMES, no bindExtensions", async () => {
+    const fakeSession = makeFakeSession();
+    mockCreateAgentSession.mockResolvedValue({ session: fakeSession });
+
+    const result = await runSubagentOnce(makeCtx(), "test prompt", MODELS[0].id);
+
+    expect(result.ok).toBe(true);
+
+    // Check DefaultResourceLoader was created with noExtensions: true, noSkills: true
+    const loaderOptions = mockDefaultResourceLoader.mock.calls[0][0];
+    expect(loaderOptions.noExtensions).toBe(true);
+    expect(loaderOptions.noSkills).toBe(true);
+
+    // Check createAgentSession was called with tools: DEFAULT_TOOL_NAMES
+    const sessionOptions = mockCreateAgentSession.mock.calls[0][0];
+    expect(sessionOptions.tools).toEqual(["bash", "read", "edit", "write", "grep", "find", "ls"]);
+
+    // bindExtensions should NOT have been called
+    expect(fakeSession.bindExtensions).not.toHaveBeenCalled();
+  });
+
+  it("allowExtensions:true: sets noExtensions=false, noSkills=false, tools=undefined, calls bindExtensions", async () => {
+    const fakeSession = makeFakeSession();
+    mockCreateAgentSession.mockResolvedValue({ session: fakeSession });
+
+    const result = await runSubagentOnce(makeCtx(), "test prompt", MODELS[0].id, undefined, {
+      allowExtensions: true,
+    });
+
+    expect(result.ok).toBe(true);
+
+    // Check DefaultResourceLoader was created with noExtensions: false, noSkills: false
+    const loaderOptions = mockDefaultResourceLoader.mock.calls[0][0];
+    expect(loaderOptions.noExtensions).toBe(false);
+    expect(loaderOptions.noSkills).toBe(false);
+
+    // Check createAgentSession was called with tools: undefined
+    const sessionOptions = mockCreateAgentSession.mock.calls[0][0];
+    expect(sessionOptions.tools).toBeUndefined();
+
+    // bindExtensions should have been called
+    expect(fakeSession.bindExtensions).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/subagent.test.ts
+++ b/test/subagent.test.ts
@@ -3,8 +3,6 @@ import {
   describeAvailableModels,
   getLastAssistantText,
   resolveModel,
-} from "../src/subagent.js";
-import {
   runSubagentOnce,
 } from "../src/subagent.js";
 
@@ -12,6 +10,9 @@ import {
 // Must be at file scope — vitest hoists vi.mock to the top automatically.
 vi.mock("@earendil-works/pi-coding-agent", () => ({
   createAgentSession: vi.fn(),
+  // Instantiated via `new DefaultResourceLoader(...)`, so the mock must be a
+  // constructable function expression — an arrow function can't be `new`-ed.
+  // biome-ignore lint/complexity/useArrowFunction: used as a constructor mock
   DefaultResourceLoader: vi.fn(function () {
     return { reload: vi.fn().mockResolvedValue(undefined) };
   }),
@@ -330,6 +331,13 @@ describe("runSubagentOnce", () => {
     expect(loaderOptions.noExtensions).toBe(false);
     expect(typeof loaderOptions.extensionsOverride).toBe("function");
 
+    // The override keeps only extensions whose path matches a requested name
+    // (substring match against the extension path).
+    const filtered = loaderOptions.extensionsOverride({
+      extensions: [{ path: "npm:pi-telegram" }, { path: "npm:pi-mcp-adapter" }],
+    });
+    expect(filtered.extensions.map((e: { path: string }) => e.path)).toEqual(["npm:pi-telegram"]);
+
     const sessionOptions = mockCreateAgentSession.mock.calls[0][0];
     expect(sessionOptions.tools).toBeUndefined();
 
@@ -350,6 +358,50 @@ describe("runSubagentOnce", () => {
     const loaderOptions = mockDefaultResourceLoader.mock.calls[0][0];
     expect(loaderOptions.noSkills).toBe(false);
     expect(typeof loaderOptions.skillsOverride).toBe("function");
+
+    // The override keeps only exactly-named skills — "git" must not match "github".
+    const filtered = loaderOptions.skillsOverride({
+      skills: [{ name: "git" }, { name: "github" }, { name: "docs" }],
+    });
+    expect(filtered.skills.map((s: { name: string }) => s.name)).toEqual(["git"]);
+
+    expect(fakeSession.bindExtensions).not.toHaveBeenCalled();
+  });
+
+  it("skills:[]: empty array means none — same as unset", async () => {
+    const fakeSession = makeFakeSession();
+    mockCreateAgentSession.mockResolvedValue({ session: fakeSession });
+
+    const result = await runSubagentOnce(makeCtx(), "test prompt", MODELS[0].id, undefined, {
+      skills: [],
+    });
+
+    expect(result.ok).toBe(true);
+
+    const loaderOptions = mockDefaultResourceLoader.mock.calls[0][0];
+    expect(loaderOptions.noSkills).toBe(true);
+    expect(loaderOptions.skillsOverride).toBeUndefined();
+
+    expect(fakeSession.bindExtensions).not.toHaveBeenCalled();
+  });
+
+  it("extensions:[]: empty array means none — same as unset", async () => {
+    const fakeSession = makeFakeSession();
+    mockCreateAgentSession.mockResolvedValue({ session: fakeSession });
+
+    const result = await runSubagentOnce(makeCtx(), "test prompt", MODELS[0].id, undefined, {
+      extensions: [],
+    });
+
+    expect(result.ok).toBe(true);
+
+    // An empty array must not widen the toolset or load extensions.
+    const loaderOptions = mockDefaultResourceLoader.mock.calls[0][0];
+    expect(loaderOptions.noExtensions).toBe(true);
+    expect(loaderOptions.extensionsOverride).toBeUndefined();
+
+    const sessionOptions = mockCreateAgentSession.mock.calls[0][0];
+    expect(sessionOptions.tools).toEqual(["bash", "read", "edit", "write", "grep", "find", "ls"]);
 
     expect(fakeSession.bindExtensions).not.toHaveBeenCalled();
   });

--- a/test/tool.test.ts
+++ b/test/tool.test.ts
@@ -334,3 +334,76 @@ describe("schedule_prompt — session binding", () => {
     expect(storage.getJob("live")).toBeDefined();
   });
 });
+
+describe("schedule_prompt — allowExtensions", () => {
+  describe("add", () => {
+    it("accepts allowExtensions=true and stores it on the job", async () => {
+      const { tool, storage } = buildTool();
+      const result = await tool.execute(
+        "call",
+        {
+          action: "add",
+          schedule: "+10s",
+          type: "once",
+          prompt: "test",
+          model: "haiku",
+          allowExtensions: true,
+        } as any,
+        undefined,
+        undefined,
+        makeCtx(),
+      );
+      expect(result.details?.error).toBeUndefined();
+      expect(result.details?.jobs?.[0].allowExtensions).toBe(true);
+    });
+
+    it("defaults allowExtensions to undefined when not provided", async () => {
+      const { tool } = buildTool();
+      const result = await tool.execute(
+        "call",
+        {
+          action: "add",
+          schedule: "+10s",
+          type: "once",
+          prompt: "test",
+          model: "haiku",
+        } as any,
+        undefined,
+        undefined,
+        makeCtx(),
+      );
+      expect(result.details?.error).toBeUndefined();
+      expect(result.details?.jobs?.[0].allowExtensions).toBeUndefined();
+    });
+  });
+
+  describe("update", () => {
+    it("accepts setting allowExtensions=true on an existing subagent job", async () => {
+      const { tool, storage } = buildTool([exampleJob({ id: "j1", model: "haiku" })]);
+      const result = await tool.execute(
+        "call",
+        { action: "update", jobId: "j1", allowExtensions: true } as any,
+        undefined,
+        undefined,
+        makeCtx(),
+      );
+      expect(result.details?.error).toBeUndefined();
+      expect(storage.getJob("j1").allowExtensions).toBe(true);
+    });
+
+    it("accepts setting allowExtensions=false on an existing subagent job", async () => {
+      const { tool, storage } = buildTool([
+        exampleJob({ id: "j1", model: "haiku", allowExtensions: true }),
+      ]);
+      const result = await tool.execute(
+        "call",
+        { action: "update", jobId: "j1", allowExtensions: false } as any,
+        undefined,
+        undefined,
+        makeCtx(),
+      );
+      expect(result.details?.error).toBeUndefined();
+      expect(storage.getJob("j1").allowExtensions).toBe(false);
+    });
+  });
+});

--- a/test/tool.test.ts
+++ b/test/tool.test.ts
@@ -338,7 +338,7 @@ describe("schedule_prompt — session binding", () => {
 describe("schedule_prompt — allowExtensions", () => {
   describe("add", () => {
     it("accepts allowExtensions=true and stores it on the job", async () => {
-      const { tool, storage } = buildTool();
+      const { tool } = buildTool();
       const result = await tool.execute(
         "call",
         {

--- a/test/tool.test.ts
+++ b/test/tool.test.ts
@@ -335,9 +335,9 @@ describe("schedule_prompt — session binding", () => {
   });
 });
 
-describe("schedule_prompt — allowExtensions", () => {
+describe("schedule_prompt — extensions/skills", () => {
   describe("add", () => {
-    it("accepts allowExtensions=true and stores it on the job", async () => {
+    it("accepts extensions=true and stores it on the job", async () => {
       const { tool } = buildTool();
       const result = await tool.execute(
         "call",
@@ -347,17 +347,17 @@ describe("schedule_prompt — allowExtensions", () => {
           type: "once",
           prompt: "test",
           model: "haiku",
-          allowExtensions: true,
+          extensions: true,
         } as any,
         undefined,
         undefined,
         makeCtx(),
       );
       expect(result.details?.error).toBeUndefined();
-      expect(result.details?.jobs?.[0].allowExtensions).toBe(true);
+      expect(result.details?.jobs?.[0].extensions).toBe(true);
     });
 
-    it("accepts allowSkills=true and stores it on the job", async () => {
+    it("accepts skills=true and stores it on the job", async () => {
       const { tool } = buildTool();
       const result = await tool.execute(
         "call",
@@ -367,17 +367,17 @@ describe("schedule_prompt — allowExtensions", () => {
           type: "once",
           prompt: "test",
           model: "haiku",
-          allowSkills: true,
+          skills: true,
         } as any,
         undefined,
         undefined,
         makeCtx(),
       );
       expect(result.details?.error).toBeUndefined();
-      expect(result.details?.jobs?.[0].allowSkills).toBe(true);
+      expect(result.details?.jobs?.[0].skills).toBe(true);
     });
 
-    it("defaults allowExtensions to undefined when not provided", async () => {
+    it("defaults extensions to undefined when not provided", async () => {
       const { tool } = buildTool();
       const result = await tool.execute(
         "call",
@@ -393,10 +393,10 @@ describe("schedule_prompt — allowExtensions", () => {
         makeCtx(),
       );
       expect(result.details?.error).toBeUndefined();
-      expect(result.details?.jobs?.[0].allowExtensions).toBeUndefined();
+      expect(result.details?.jobs?.[0].extensions).toBeUndefined();
     });
 
-    it("defaults allowSkills to undefined when not provided", async () => {
+    it("defaults skills to undefined when not provided", async () => {
       const { tool } = buildTool();
       const result = await tool.execute(
         "call",
@@ -412,65 +412,65 @@ describe("schedule_prompt — allowExtensions", () => {
         makeCtx(),
       );
       expect(result.details?.error).toBeUndefined();
-      expect(result.details?.jobs?.[0].allowSkills).toBeUndefined();
+      expect(result.details?.jobs?.[0].skills).toBeUndefined();
     });
   });
 
   describe("update", () => {
-    it("accepts setting allowExtensions=true on an existing subagent job", async () => {
+    it("accepts setting extensions=true on an existing subagent job", async () => {
       const { tool, storage } = buildTool([exampleJob({ id: "j1", model: "haiku" })]);
       const result = await tool.execute(
         "call",
-        { action: "update", jobId: "j1", allowExtensions: true } as any,
+        { action: "update", jobId: "j1", extensions: true } as any,
         undefined,
         undefined,
         makeCtx(),
       );
       expect(result.details?.error).toBeUndefined();
-      expect(storage.getJob("j1").allowExtensions).toBe(true);
+      expect(storage.getJob("j1").extensions).toBe(true);
     });
 
-    it("accepts setting allowExtensions=false on an existing subagent job", async () => {
+    it("accepts setting extensions=false on an existing subagent job", async () => {
       const { tool, storage } = buildTool([
-        exampleJob({ id: "j1", model: "haiku", allowExtensions: true }),
+        exampleJob({ id: "j1", model: "haiku", extensions: true }),
       ]);
       const result = await tool.execute(
         "call",
-        { action: "update", jobId: "j1", allowExtensions: false } as any,
+        { action: "update", jobId: "j1", extensions: false } as any,
         undefined,
         undefined,
         makeCtx(),
       );
       expect(result.details?.error).toBeUndefined();
-      expect(storage.getJob("j1").allowExtensions).toBe(false);
+      expect(storage.getJob("j1").extensions).toBe(false);
     });
 
-    it("accepts setting allowSkills=true on an existing subagent job", async () => {
+    it("accepts setting skills=true on an existing subagent job", async () => {
       const { tool, storage } = buildTool([exampleJob({ id: "j2", model: "haiku" })]);
       const result = await tool.execute(
         "call",
-        { action: "update", jobId: "j2", allowSkills: true } as any,
+        { action: "update", jobId: "j2", skills: true } as any,
         undefined,
         undefined,
         makeCtx(),
       );
       expect(result.details?.error).toBeUndefined();
-      expect(storage.getJob("j2").allowSkills).toBe(true);
+      expect(storage.getJob("j2").skills).toBe(true);
     });
 
-    it("accepts setting allowSkills=false on an existing subagent job", async () => {
+    it("accepts setting skills=false on an existing subagent job", async () => {
       const { tool, storage } = buildTool([
-        exampleJob({ id: "j2", model: "haiku", allowSkills: true }),
+        exampleJob({ id: "j2", model: "haiku", skills: true }),
       ]);
       const result = await tool.execute(
         "call",
-        { action: "update", jobId: "j2", allowSkills: false } as any,
+        { action: "update", jobId: "j2", skills: false } as any,
         undefined,
         undefined,
         makeCtx(),
       );
       expect(result.details?.error).toBeUndefined();
-      expect(storage.getJob("j2").allowSkills).toBe(false);
+      expect(storage.getJob("j2").skills).toBe(false);
     });
   });
 });

--- a/test/tool.test.ts
+++ b/test/tool.test.ts
@@ -357,6 +357,26 @@ describe("schedule_prompt — allowExtensions", () => {
       expect(result.details?.jobs?.[0].allowExtensions).toBe(true);
     });
 
+    it("accepts allowSkills=true and stores it on the job", async () => {
+      const { tool } = buildTool();
+      const result = await tool.execute(
+        "call",
+        {
+          action: "add",
+          schedule: "+10s",
+          type: "once",
+          prompt: "test",
+          model: "haiku",
+          allowSkills: true,
+        } as any,
+        undefined,
+        undefined,
+        makeCtx(),
+      );
+      expect(result.details?.error).toBeUndefined();
+      expect(result.details?.jobs?.[0].allowSkills).toBe(true);
+    });
+
     it("defaults allowExtensions to undefined when not provided", async () => {
       const { tool } = buildTool();
       const result = await tool.execute(
@@ -374,6 +394,25 @@ describe("schedule_prompt — allowExtensions", () => {
       );
       expect(result.details?.error).toBeUndefined();
       expect(result.details?.jobs?.[0].allowExtensions).toBeUndefined();
+    });
+
+    it("defaults allowSkills to undefined when not provided", async () => {
+      const { tool } = buildTool();
+      const result = await tool.execute(
+        "call",
+        {
+          action: "add",
+          schedule: "+10s",
+          type: "once",
+          prompt: "test",
+          model: "haiku",
+        } as any,
+        undefined,
+        undefined,
+        makeCtx(),
+      );
+      expect(result.details?.error).toBeUndefined();
+      expect(result.details?.jobs?.[0].allowSkills).toBeUndefined();
     });
   });
 
@@ -404,6 +443,34 @@ describe("schedule_prompt — allowExtensions", () => {
       );
       expect(result.details?.error).toBeUndefined();
       expect(storage.getJob("j1").allowExtensions).toBe(false);
+    });
+
+    it("accepts setting allowSkills=true on an existing subagent job", async () => {
+      const { tool, storage } = buildTool([exampleJob({ id: "j2", model: "haiku" })]);
+      const result = await tool.execute(
+        "call",
+        { action: "update", jobId: "j2", allowSkills: true } as any,
+        undefined,
+        undefined,
+        makeCtx(),
+      );
+      expect(result.details?.error).toBeUndefined();
+      expect(storage.getJob("j2").allowSkills).toBe(true);
+    });
+
+    it("accepts setting allowSkills=false on an existing subagent job", async () => {
+      const { tool, storage } = buildTool([
+        exampleJob({ id: "j2", model: "haiku", allowSkills: true }),
+      ]);
+      const result = await tool.execute(
+        "call",
+        { action: "update", jobId: "j2", allowSkills: false } as any,
+        undefined,
+        undefined,
+        makeCtx(),
+      );
+      expect(result.details?.error).toBeUndefined();
+      expect(storage.getJob("j2").allowSkills).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Hi @tintinweb,

This PR fixes #13. Subagent jobs from cron can't load extensions. As a bonus, it also enables skills for those jobs.

### #13 — Subagent jobs can't use extensions

When a cron job runs a subagent, it gets `noExtensions=true, noSkills=true, tools=DEFAULT_TOOL_NAMES`. That means no Telegram, no MCP tools, no custom skills — just the basic toolbox. Useful for simple prompts, but anything that needs an extension (send a Telegram message, use a browser, call an external API) is dead on arrival.

**Fix:** Add `extensions` and `skills` fields to the job config. Both accept `boolean | string[]`.

| Value | Meaning |
|-------|---------|
| `true` | All extensions/skills |
| `false` or unset | None (default) |
| `["pkg1", "pkg2"]` | Only the named ones |

Behind the scenes, we pass `extensionsOverride` and `skillsOverride` callbacks to `DefaultResourceLoader` — Pi already supports selective loading; we just expose it.

```json
{
  "name": "telegram-summary",
  "schedule": "0 8 * * *",
  "prompt": "Send me the morning briefing via Telegram",
  "model": "haiku",
  "extensions": ["telegram"]
}
```

Since the `model` field already decides whether a job runs inline or in a subagent, `extensions` and `skills` are no-ops for inline jobs.

### Tests

95 tests cover the feature: defaults unchanged, all-on, all-off, named lists for both extensions and skills, and the cron-widget render doesn't crash on undefined `runCount`.

Cheers